### PR TITLE
Allow using external rtl_tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ general:
   # Set the verbosity level. It can be debug or info
   verbosity: debug
 
+# (Optional section) -- Use this to point to an externally running instance of rtl_tcp
+rtltcp:
+  use_external: true # set to true to enable external rtl_tcp
+  host: 127.0.0.1 # host running rtl_tcp
+  port: 1234 #port on host running rtl_tcp
+
 # (Required section)
 # MQTT configuration
 mqtt:

--- a/rtlamt2mqtt.yaml
+++ b/rtlamt2mqtt.yaml
@@ -2,6 +2,11 @@ general:
   sleep_for: 0
   verbosity: debug
 
+rtltcp:
+  use_external: true
+  host: 127.0.0.1
+  port: 1234
+
 mqtt:
   host: 127.0.0.1
   user: test


### PR DESCRIPTION
This is a simple tweak to allow running rtl_tcp outside of the rtlamr2mqtt container, with supporting config in YAML and an updated README.