### PR TITLE
Make anonymous mqtt connection work in HA add on.

### DIFF
--- a/rtlamr2mqtt.py
+++ b/rtlamr2mqtt.py
@@ -18,7 +18,7 @@ test_mode = True if str(os.environ.get('TEST')).lower() in ['yes', 'true'] else 
 
 # Publish message function
 def publish_message(**kwargs):
-    if 'username' in kwargs:
+    if 'username' in kwargs and len(kwargs['username']) != 0:
         auth = { 'username': kwargs['username'], 'password': kwargs['password'] }
     else:
         auth = None


### PR DESCRIPTION
Unless I am mistaken, the config for home assistant will always make a mqtt: user: '' option. It defaults to empty.

This just adds to the check that the username was present and also not zero length. If the username is present and zero length, then it will continue anonymously