### PR TITLE
Add "device_class" to the entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,19 @@ meters:
     # A number format to be used for your meter
     format: "#####.###"
     # A measurement unit to be used by Home Assistant
+    # Typical values are ft³ and m³ (use the superscript) for water/gas meters
+    # and kWh or Wh for electric meters
     unit_of_measurement: "\u33A5"
     # An icon to be used by Home Assistant
     icon: mdi:gauge
+    # A device_class to define what the sensor is measuring for use in the Energy panel
+    # Typical values are "gas" or "energy". Default is blank.
+    device_class:
   - id: 6567984
     protocol: scm
     name: meter_hydro
     unit_of_measurement: kWh
+    device_class: energy
 ```
 
 ### Docker compose configuration:

--- a/rtlamr2mqtt.py
+++ b/rtlamr2mqtt.py
@@ -177,6 +177,7 @@ def send_ha_autodiscovery(meter, consumption_key):
         'unique_id': str(meter['id']),
         'unit_of_measurement': meter['unit_of_measurement'],
         'icon': meter['icon'],
+        'device_class': meter['device_class'],
         'availability_topic': availability_topic,
         'state_class': 'total_increasing',
         'state_topic': meter['state_topic'],
@@ -299,6 +300,7 @@ for idx,meter in enumerate(config['meters']):
     meters[id]['name'] = meter_name
     meters[id]['unit_of_measurement'] = str(meter.get('unit_of_measurement', ''))
     meters[id]['icon'] = str(meter.get('icon', 'mdi:gauge'))
+    meters[id]['device_class'] = str(meter.get('device_class', ''))
     meters[id]['sent_HA_discovery'] = False
     protocols.append(meter['protocol'])
     meter_ids.append(id)

--- a/rtlamr2mqtt.yaml
+++ b/rtlamr2mqtt.yaml
@@ -20,3 +20,4 @@ meters:
     format: "######.###"
     unit_of_measurement: "\u33A5"
     icon: mdi:gauge
+    device_class: energy


### PR DESCRIPTION
Using device_class helps with integrating the sensors into the Energy panel. In my case, I needed to use device_class = gas to get my gas meter recognized. Using the energy device_class could be unambiguous for electric meters. I don't think there is a compatible device_class for water meters yet, but leaving it blank should be OK in those cases.

This pull adds device_class to the HA discovery payload and the YAML config file, sets the default to be blank, and adds a few explanatory lines to the Readme. I don't code often so please catch me if I've done something incorrect. Thanks!