### PR TITLE
Document how to install rtlamr2mqtt as an add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I am using this one: [NooElec NESDR Mini USB](https://www.amazon.ca/NooElec-NESD
 ![image](https://user-images.githubusercontent.com/757086/117556120-207bd200-b02b-11eb-9149-58eaf9c6c4ea.png)
 ### How to run and configure?
 Docker and Docker-compose are the most indicated way.
-If you are not running the add-on, you must write the **rtlamr2mqtt.yaml** configuration file.
+If you are not [running the add-on[(https://www.home-assistant.io/common-tasks/os#installing-third-party-add-ons), you must write the **rtlamr2mqtt.yaml** configuration file.
 
 Create the config file on `/opt/rtlamr2mqtt/rtlamr2mqtt.yaml` for instance.
 The configuration must looks like this:
@@ -99,8 +99,6 @@ meters:
     # Typical values are ft³ and m³ (use the superscript) for water/gas meters
     # and kWh or Wh for electric meters
     unit_of_measurement: "\u33A5"
-    # (optional) The device_class if you want to specify one
-    device_class: none
     # (optional) An icon to be used by Home Assistant
     icon: mdi:gauge
     # A device_class to define what the sensor is measuring for use in the Energy panel


### PR DESCRIPTION
 - Link out to how to install rtlamr2mqtt as an add-on
 - Remove redundant device_class documentation section

Fixes #77