### PR TITLE
Add support for automatically inferring the mqtt configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
       python3-yaml \
       python3-tinydb \
       python3-sklearn \
+      python3-requests \
       libusb-1.0-0 \
     && apt-get --purge autoremove -y perl \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -59,19 +59,24 @@ general:
   # For me, this started to cause the rtl_tcp to refuse connections and miss the readings.
   tickle_rtl_tcp: false
 
-# (Required section)
-# MQTT configuration
+# MQTT configuration.
 mqtt:
-  # MQTT host name or IP address
-  host: 192.168.1.1
-  # MQTT user name if you have, remove if you don't use authentication
-  user: mqtt
-  # MQTT user password if you use one, remove if you don't use authentication
-  password: my-very-strong-password
   # Whether to use Home Assistant auto-discovery feature or not
   ha_autodiscovery: true
   # Home Assistant auto-discovery topic
   ha_autodiscovery_topic: homeassistant
+
+  # By default, leaving host, port, user, and password unset will tell
+  # rtlamr2mqtt to use the default home assistant mqtt settings for those
+  # options. If needed, you can override these default settings:
+  # MQTT host name or IP address.
+  host: 192.168.1.1
+  # MQTT port.
+  port: 1883
+  # MQTT user name if you have, remove if you don't use authentication
+  user: mqtt
+  # MQTT user password if you use one, remove if you don't use authentication
+  password: my-very-strong-password
 
 # (Optional)
 # This entire section is optional.

--- a/rtlamr2mqtt-addon/config.json
+++ b/rtlamr2mqtt-addon/config.json
@@ -14,6 +14,7 @@
     "udev": true,
     "usb": true,
     "host_network": false,
+    "hassio_api": true,
     "arch": [
         "amd64",
         "armv7",
@@ -27,10 +28,6 @@
             "tickle_rtl_tcp": false
         },
         "mqtt": {
-            "host": "hassio.local",
-            "port": 1883,
-            "user": "",
-            "password": "",
             "ha_autodiscovery": true,
             "ha_autodiscovery_topic": "homeassistant"
         },


### PR DESCRIPTION
The supervisor API exposes this information: https://developers.home-assistant.io/docs/api/supervisor/endpoints/#service

If a user configures any of mqtt.{host,port,user,password}, we trust
that the user knows what they're doing and use their configuration. If
none of mqtt.{host,port,user,password} are configured, we pull the
default configuration from the API and use that.

Fixes #79