### PR TITLE
Fix bad regex for 'single' default configs

### DIFF
--- a/rtlamr2mqtt-addon/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/rtlamr2mqtt.py
@@ -437,9 +437,9 @@ if __name__ == "__main__":
         if re.match(r"(^(0[xX])?[A-Fa-f0-9]{4}:(0[xX])?[A-Fa-f0-9]{4}$)", usb_device_id) is not None:
             usb_device_index = '-d {}'.format(str(usb_devices[usb_device_id]['index']))
             usb_port = str(usb_devices[usb_device_id]['bus_address'])
-        elif re.match(r"(^[0-9]{3}:([0-9]{3}$)))", usb_device_id) is not None:
-            log_message('Using USB port ID: {}'.format(device_id))
-            usb_port = device_id
+        elif re.match(r"(^[0-9]{3}:([0-9]{3}$))", usb_device_id) is not None:
+            log_message('Using USB port ID: {}'.format(usb_device_id))
+            usb_port = usb_device_id
         else:
             log_message('No USB device specified in the config file, using the first found.')
             usb_device_id = list(usb_devices.keys())[0]


### PR DESCRIPTION
Fixes an issue with the regex matching on USB Device IDs for default configurations