### PR TITLE
Minor docker run command device flag fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ If you want to run with docker alone, run this command:
 docker run --name rtlamr2mqtt \
   -v /opt/rtlamr2mqtt/rtlamr2mqtt.yaml:/etc/rtlamr2mqtt.yaml \
   -v /opt/rtlamr2mqtt/data:/var/lib/rtlamr2mqtt \
-  -d /dev/bus/usb:/dev/bus/usb \
+  --device /dev/bus/usb:/dev/bus/usb \
   --restart unless-stopped \
   allangood/rtlamr2mqtt
 ```


### PR DESCRIPTION
Changes -d to --device to work with later versions of docker (and matches the later docker run commands in the README).