### PR TITLE
Add support for the MQTT integration's `expire_after` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The project is currently under heavy development!
 - Sleep after successful reading to avoid heating the CPU too much (`sleep_for` config option)
 - Support multiple meters with one instance
 - Run as an Addon for Home Assistant with Supervisor support and MQTT auto configuration
-- Full sensor customization: `name`, `state_class`, `device_class`, `icon` and `unit_of_measurement`
+- Full sensor customization: `name`, `state_class`, `device_class`, `expire_after`, `icon` and `unit_of_measurement`
 
 ### Planned features
 
@@ -189,6 +189,9 @@ meters:
     # "total_increasing" for most meters, "total" for meters that might go
     # backwards (net energy meters). Defaults to "total_increasing" if unset.
     state_class:
+    # (optional) Make the Home Assistant sensor `unavailable` after this many seconds without a reading
+    # Default is 0, which means the sensor will never be marked unavailable due to lack of readings.
+    expire_after:
   - id: 6567984
     protocol: scm
     name: meter_hydro

--- a/rtlamr2mqtt-addon/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/rtlamr2mqtt.py
@@ -318,6 +318,8 @@ def send_ha_autodiscovery(meter, mqtt_config):
     }
     if meter['device_class'] is not None:
         discover_payload['device_class'] = meter['device_class']
+    if meter['expire_after'] is not None:
+        discover_payload['expire_after'] = meter['expire_after']
     mqtt_sender.publish(topic=discover_topic, payload=dumps(discover_payload), qos=1, retain=True)
 
 def tickle_rtl_tcp(remote_server):
@@ -472,6 +474,7 @@ if __name__ == "__main__":
         meters[meter_id]['device_class'] = str(meter.get('device_class', None))
         if meters[meter_id]['device_class'].lower() in ['none', 'null']:
             meters[meter_id]['device_class'] = None
+        meters[meter_id]['expire_after'] = meter.get('expire_after', None)
         meters[meter_id]['sent_HA_discovery'] = False
 
         protocols.append(meter['protocol'])

--- a/rtlamr2mqtt-addon/rtlamr2mqtt.yaml
+++ b/rtlamr2mqtt-addon/rtlamr2mqtt.yaml
@@ -53,7 +53,7 @@ meters:
     protocol: scm+
     # A nice name to show on HA
     name: test_meter
-    # Format of you meter
+    # Format of your meter
     format: "######.###"
     # Unit of measurement to show on HA
     unit_of_measurement: "\u33A5"
@@ -61,3 +61,5 @@ meters:
     icon: mdi:gauge
     # device_class on HA
     device_class: energy
+    # expire_after on HA
+    expire_after: 900


### PR DESCRIPTION
First off, thanks for this great project! I have been using it for months to get usage from my gas and water meters into HA.

Recently I discovered that I was missing a couple weeks of data for my sensors - rtlamr2mqtt had stopped collecting and sending sensor information to MQTT. It apparently didn't lose its MQTT connection, because it didn't publish the LWT message. I didn't see any obvious issues and a restart solved it, so I focused on finding a way to alert and recover from this if it happened again.

It turns out, Home Assistant's MQTT integration has a setting called [`expire_after`](https://www.home-assistant.io/integrations/sensor.mqtt/#expire_after) which is exactly what I am looking for:
> If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable. Default the sensors state never expires.

This PR doesn't change the default behavior, but if `expire_after` is provided for a meter, it will pass that option into the MQTT discovery payload, which HA will use to cause the sensor to become `unavailable` after `expire_after` seconds have passed without a sensor reading. This should thus be set to something larger than the expected period between sensor readings (e.g. larger than `sleep_for`).

Thanks again!