### PR TITLE
add device_class: water to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ meters:
     icon: mdi:gauge
     # A device_class to define what the sensor is measuring for use in the Energy panel
     # Typical values are "gas" or "energy". Default is blank.
-    device_class:
+    device_class: water
     # "total_increasing" for most meters, "total" for meters that might go
     # backwards (net energy meters). Defaults to "total_increasing" if unset.
     state_class:


### PR DESCRIPTION
Adds `device_class: water` to example water meter config in README per #165 