### PR TITLE
Update Dockerfile

### DIFF
--- a/rtlamr2mqtt-addon/Dockerfile
+++ b/rtlamr2mqtt-addon/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/app
 RUN go install github.com/bemasher/rtlamr@latest \
     && apt-get update \
     && apt-get install -y libusb-1.0-0-dev build-essential git cmake \
-    && git clone git://git.osmocom.org/rtl-sdr.git \
+    && git clone https://git.osmocom.org/rtl-sdr.git \
     && cd rtl-sdr \
     && mkdir build && cd build \
     && cmake .. -DDETACH_KERNEL_DRIVER=ON -DENABLE_ZEROCOPY=ON -Wno-dev \


### PR DESCRIPTION
Changed clone URL from git: to https:
This is in response to the issue I was having trying to install. Please decline if this is not the appropriate solution. Fixes Unable to install from HACS #220