### PR TITLE
Change Last Seen device_class to `timestamp`

### DIFF
--- a/rtlamr2mqtt-addon/app/helpers/ha_messages.py
+++ b/rtlamr2mqtt-addon/app/helpers/ha_messages.py
@@ -39,7 +39,7 @@ def meter_discover_payload(base_topic, meter_config):
             f"{meter_id}_lastseen": {
                 "platform": "sensor",
                 "name": "Last Seen",
-                "device_class": "date",
+                "device_class": "timestamp",
                 "value_template":"{{ value_json.lastseen }}",
                 "unique_id": f"{meter_id}_lastseen"
             }


### PR DESCRIPTION
First off, thanks for all of your work on this project! I've been using it for years and it works great; I'm excited for the new updates!

I was going to open this as a Feature Request issue, but since it's a one-line change (as far as I can tell) I figured I'd open it as a PR for efficiency purposes. If you'd prefer an issue instead, please let me know and I'd be happy to open one.

I've been trying out 2025.6.x, and right now the device's `Last Seen` sensor in Home Assistant is just a date (YYYY-MM-DD).
<img width="319" alt="Image" src="https://github.com/user-attachments/assets/bed76dbe-b676-4892-9f00-66d8bea5e057" />

I believe this is because the `device_class` reported in the JSON device payload for the last seen component is `date`:

```
{
   [snip]
    "components": {
        "123123123_reading": {
            [snip]
        },
        "123123123_lastseen": {
            "platform": "sensor",
            "name": "Last Seen",
            "device_class": "date",
            "value_template": "{{ value_json.lastseen }}",
            "unique_id": "123123123_lastseen"
        }
    }
}
```

However, the actual payload includes a full timestamp for last seen:
```
INFO:Publishing to rtlamrbeta/123123123/state: {"reading": "1234.5", "lastseen": "2025-06-09T23:44:00+00:00"}
```

If the `device_class` is changed to Timestamp, the Last Seen entity gets much more specific:
<img width="331" alt="Image" src="https://github.com/user-attachments/assets/ff9b587d-287c-48ca-ae5c-b77f948ca5f2" />

<img width="587" alt="Image" src="https://github.com/user-attachments/assets/e59acc25-ed22-4364-b8f8-39f7f8b53e21" />

ref: https://www.home-assistant.io/integrations/sensor/#device-class