### PR TITLE
Add missing config keys to Reading sensor

### DIFF
--- a/rtlamr2mqtt-addon/app/helpers/ha_messages.py
+++ b/rtlamr2mqtt-addon/app/helpers/ha_messages.py
@@ -32,6 +32,12 @@ def meter_discover_payload(base_topic, meter_config):
             f"{meter_id}_reading": {
                 "platform": "sensor",
                 "name": "Reading",
+                "unit_of_measurement": meter_config['unit_of_measurement'],
+                "icon": meter_config.get('icon', 'mdi:guage'),
+                "device_class": meter_config['device_class'],
+                "state_class": meter_config.get('state_class', 'total'),
+                "expire_after": meter_config.get('expire_after', 0),
+                "force_update": meter_config.get('force_update', True),
                 "value_template": "{{ value_json.reading|float }}",
                 "json_attributes_topic": f"{base_topic}/{meter_id}/attributes",
                 "unique_id": f"{meter_id}_reading"


### PR DESCRIPTION
This pull request adds additional keys from the config file to the discovery message to ensure that `device_class` and `state_class` are set to enable the sensor to be used in the HA Energy Dashboard. `state_class` defaults to `total` with `last_reset = None` as per the HA developer guide.