### PR TITLE
Conditional for info logging to prevent log spam.

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -361,7 +361,8 @@ def main():
                             )
                     sys.exit(1)
             else:
-                logger.info('Using remote RTL_TCP server at %s', config['general']['rtltcp_host'])
+                if LOG_LEVEL >= 3:
+                    logger.info('Using remote RTL_TCP server at %s', config['general']['rtltcp_host'])
                 # If we are using a remote RTL_TCP server, we can skip the rest of the setup
                 # and just read from the remote server
                 rtltcp = None


### PR DESCRIPTION
The log line for "Using remote RTL_TCP server: " is repeated every second or so, even though I have the verbosity in config set to 'warning'.

general config
```
sleep_for: 0
verbosity: warning
```

