### PR TITLE
Improve MQTT connection and logging

### DIFF
--- a/rtlamr2mqtt-addon/DOCS.md
+++ b/rtlamr2mqtt-addon/DOCS.md
@@ -111,6 +111,9 @@ mqtt:
   # BEFORE ASKING FOR SUPPORT, CHANGE TO false, STOP,
   # DELETE RETAINED MESSAGES, AND RESTART
   retain: false
+  # MQTT protocol version. Valid values are 3, 4, and 5, corresponding to 3.1,
+  # 3.1.1, and 5. Defaults to 4.
+  protocol: 4
 
 # Optional section
 # If you need to pass parameters to rtl_tcp or rtlamr

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -6,6 +6,7 @@ import os
 import requests
 from json import load
 from yaml import safe_load
+from paho.mqtt.enums import MQTTProtocolVersion
 
 
 def get_mqtt_info_from_supervisor(mqtt_config):
@@ -105,6 +106,12 @@ def load_config(config_path=None):
     mqtt['ha_status_topic'] = str(mqtt.get('ha_status_topic', 'homeassistant/status'))
     mqtt['ha_autodiscovery_topic'] = mqtt.get('ha_autodiscovery_topic', 'homeassistant')
     mqtt['retain'] = bool(mqtt.get('retain', False))
+    try:
+        mqtt['protocol'] = int(mqtt.get('protocol', 4))
+    except ValueError as e:
+        return ('error', f"Invalid protocol version {mqtt['protocol']} for MQTT.", None)
+    if mqtt['protocol'] not in [p.value for p in MQTTProtocolVersion]:
+        return ('error', f"Invalid protocol version {mqtt['protocol']} for MQTT.", None)
 
     # Custom parameters section
     custom_parameters['rtltcp'] = str(custom_parameters.get('rtltcp', '-s 2048000'))

--- a/rtlamr2mqtt-addon/app/helpers/mqtt_client.py
+++ b/rtlamr2mqtt-addon/app/helpers/mqtt_client.py
@@ -4,18 +4,18 @@ Helper functions for MQTT connection
 
 import ssl
 import paho.mqtt.client as mqtt
-from paho.mqtt.enums import MQTTErrorCode,CallbackAPIVersion
+from paho.mqtt.enums import MQTTErrorCode,CallbackAPIVersion,MQTTProtocolVersion
 from uuid import uuid4
 
 class MQTTClient:
     """
     A class to handle MQTT client operations.
     """
-    def __init__(self, logger, broker, port, username=None, password=None, tls_enabled=False, ca_cert=None, client_cert=None, tls_insecure=False, client_key=None, log_level=4):
+    def __init__(self, logger, broker, port, username=None, password=None, tls_enabled=False, ca_cert=None, client_cert=None, tls_insecure=False, client_key=None, log_level=4, protocol=MQTTProtocolVersion.MQTTv311):
         """
         Initialize the MQTT client.
         """
-        self.client = mqtt.Client(client_id=f'rtlamr2mqtt-{uuid4().hex[-8:]}', callback_api_version = CallbackAPIVersion.VERSION2)
+        self.client = mqtt.Client(client_id=f'rtlamr2mqtt-{uuid4().hex[-8:]}', callback_api_version = CallbackAPIVersion.VERSION2, protocol=protocol)
         self.broker = broker
         self.port = port
         self.logger = logger

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -265,6 +265,7 @@ def main():
         ca_cert=config['mqtt']['tls_ca'],
         client_cert=config['mqtt']['tls_cert'],
         client_key=config['mqtt']['tls_keyfile'],
+        protocol=config['mqtt']['protocol'],
         log_level=LOG_LEVEL,
         logger=logger,
     )

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.yaml
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.yaml
@@ -43,6 +43,9 @@ mqtt:
   # BEFORE ASKING FOR SUPPORT, CHANGE TO false, STOP,
   # DELETE RETAINED MESSAGES, AND RESTART
   retain: false
+  # MQTT protocol version. Valid values are 3, 4, and 5, corresponding to 3.1,
+  # 3.1.1, and 5. Defaults to 4.
+  protocol: 4
 
 # Optional section
 # If you need to pass parameters to rtl_tcp or rtlamr

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -56,6 +56,7 @@ schema:
     ha_status_topic: "str?"
     base_topic: "str?"
     retain: "bool?"
+    protocol: "list(3|4|5)"
   custom_parameters:
     rtltcp: "str?"
     rtlamr: "str?"


### PR DESCRIPTION
**Problem**

I forgot I had an ACL, and rtlamr2mqtt **silently** didn't work, as seen by HA/the user. Same would have happened if I got the user/password wrong and disallowed anonymous login (which I do, but I didn't get that setup wrong).

From testing, the [current connect try](https://github.com/allangood/rtlamr2mqtt/blob/ac0aead02aa948d380c86f9048c7f6c30641650b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py#L280) will only catch DNS/TCP/TLS level errors, not protocol level errors such as not being authorized.

MQTT protocol < 5 has very limited error reporting capabilities.

**PR**

This PR:

* Adds the option to use MQTTv5 (defaults to 311)
* Blocks until the initial MQTT connection is made, or fails after some automatic retries. Similar to the existing try/catch, I thought failing to get a successful CONNACK should abort startup entirely.
* Adds logging of error conditions when available: For MQTTv311, on connect and on subscribe (it would be very hard for the current code to see a failed sub, but still). For MQTTv5, error conditions on publish are logged as well (this is a protocol level addition).  I chose not to make the errors kill the process because paho-mqtt has `reconnect_on_failure` set to True by default so it should handle temporary failures, but let me know if you think errors (like not being authorized) should be fatal.
* Internal implementation note: uses paho-mqtt callback API v2 instead of the default v1, so we can get those error codes.

Please let me know if you have any suggestions!

**Testing**

I built the mock docker container and ran it with different configurations (of rtlamr2mqtt and mosquitto).

Test output with debug and protocol 5 set, and an ACL configured to deny the rtlamr2mqtt user:

```
[2025-08-08 01:24:00,156] INFO:MQTT: Publishing to homeassistant/device/157590000/config  with qos=1 and retain=False: {"device": {"identifiers": "meter_157590000", "...
[2025-08-08 01:24:00,156] DEBUG:MQTT: `- mid for this publish is 2
[2025-08-08 01:24:00,160] ERROR:MQTT: Unable to publish mid 2 (Not authorized)
```

<details><summary>Illustration of protocol 311 incorrectly claiming success</summary>
Same setup as before, the MQTT server actually denied this write:

```
2025-08-08 01:25:45,585] INFO:MQTT: Publishing to homeassistant/device/157590000/config  with qos=1 and retain=False: {"device": {"identifiers": "meter_157590000", "...
[2025-08-08 01:25:45,585] DEBUG:MQTT: `- mid for this publish is 2
[2025-08-08 01:25:45,597] INFO:MQTT: Successfully published mid 2
```
```
Aug  7 21:25:45 docker/prod-mosquitto-server[1916]: Denied PUBLISH from rtlamr2mqtt-83691e6a (d0, q1, r0, m2, 'homeassistant/device/157590000/config', ... (994 bytes))
```
</details>

With the wrong user/pass and anonymous connections disabled:

```
[2025-08-08 01:28:53,414] INFO:Starting rtlamr2mqtt 2025.6.6
[2025-08-08 01:28:53,417] INFO:Config loaded successfully
[2025-08-08 01:28:53,434] INFO:MQTT: Connecting to MQTT broker at tarkin:5649
[2025-08-08 01:28:53,452] ERROR:MQTT: Unable to connect to tarkin:5649 (Not authorized)
[2025-08-08 01:28:54,465] ERROR:MQTT: Unable to connect to tarkin:5649 (Not authorized)
[2025-08-08 01:28:56,477] ERROR:MQTT: Unable to connect to tarkin:5649 (Not authorized)
[2025-08-08 01:29:00,488] ERROR:MQTT: Unable to connect to tarkin:5649 (Not authorized)
[2025-08-08 01:29:02,451] CRITICAL:Failed to connect to MQTT broker
```

Smoke test, publishing still works, here's another `mosquitto_sub` seeing the publish of a mock device:

```
Client null received PUBLISH (d0, q0, r0, m0, 'rtlamr-test/60706301/state', ... (66 bytes))
rtlamr-test/60706301/state {"reading": "0076219.74", "lastseen": "2025-08-08T01:33:36+00:00"}
Client null received PUBLISH (d0, q0, r0, m0, 'rtlamr-test/60706301/attributes', ... (84 bytes))
rtlamr-test/60706301/attributes {"Type": 7, "TamperPhy": 1, "TamperEnc": 2, "ChecksumVal": 48922, "protocol": "SCM"}
```