### PR TITLE
Set Docker entrypoints to dumb-init so it can reap defunct children

### DIFF
--- a/rtlamr2mqtt-addon/Dockerfile
+++ b/rtlamr2mqtt-addon/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     && apt-get install -o Dpkg::Options::="--force-confnew" -y \
       libusb-1.0-0 \
       expect \
+      dumb-init \
     && apt-get --purge autoremove -y \
     && apt-get clean \
     && find /var/lib/apt/lists/ -type f -delete \
@@ -37,4 +38,5 @@ RUN apt-get update \
 
 STOPSIGNAL SIGTERM
 
-ENTRYPOINT ["python", "/opt/venv/app/rtlamr2mqtt.py"]
+ENTRYPOINT ["dumb-init"]
+CMD ["python", "/opt/venv/app/rtlamr2mqtt.py"]

--- a/rtlamr2mqtt-addon/Dockerfile.mock
+++ b/rtlamr2mqtt-addon/Dockerfile.mock
@@ -11,7 +11,8 @@ COPY requirements.txt /tmp
 RUN apt-get update && \
     apt-get install -o Dpkg::Options::="--force-confnew" -y \
       libusb-1.0-0 \
-      expect && \
+      expect \
+      dumb-init && \
     python3 -m venv $VIRTUAL_ENV && \
     pip install -r /tmp/requirements.txt && \
     rm -rf /usr/share/doc /tmp/requirements.txt
@@ -20,4 +21,5 @@ COPY ./app/ $VIRTUAL_ENV/app/
 
 STOPSIGNAL SIGTERM
 
-ENTRYPOINT ["python", "/opt/venv/app/rtlamr2mqtt.py"]
+ENTRYPOINT ["dumb-init"]
+CMD ["python", "/opt/venv/app/rtlamr2mqtt.py"]


### PR DESCRIPTION
Fixes #341

Use dumb-init to reap defunct subprocesses instead of leaving a bunch of <defunct> PIDs around