### PR TITLE
Respect LOG_LEVEL for remote RTL_TCP log message

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -370,7 +370,8 @@ def main():
                             )
                     sys.exit(1)
             else:
-                logger.info('Using remote RTL_TCP server at %s', config['general']['rtltcp_host'])
+                if LOG_LEVEL >= 3:
+                    logger.info('Using remote RTL_TCP server at %s', config['general']['rtltcp_host'])
                 # If we are using a remote RTL_TCP server, we can skip the rest of the setup
                 # and just read from the remote server
                 rtltcp = None


### PR DESCRIPTION
Fixes #333

## Problem
When using a remote RTL_TCP server with verbosity set to warning or error, the log message "Using remote RTL_TCP server at..." was still being printed every second, filling the buffer and making it difficult to identify actual meter updates.

## This PR
- Adds LOG_LEVEL check before the remote RTL_TCP log message
- Makes the logging behavior consistent with all other logger.info() calls in the codebase
