### PR TITLE
Reset killed subprocess variables

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -459,6 +459,8 @@ def main():
                     logger.info('Sleeping for %d seconds...', config["general"]["sleep_for"])
                 # Shutdown everything, but mqtt_client
                 shutdown(rtlamr=rtlamr, rtltcp=rtltcp, mqtt_client=None)
+                # Reset killed subprocess variables
+                rtlamr = rtltcp = None
                 read_counter = []
                 try:
                     sleep(int(config['general']['sleep_for']))


### PR DESCRIPTION
I started using this add on recently with my stack have really enjoyed the implementation; it is exactly what I was looking for. One small tic I did notice though is that after a sleep cycle, the add on was reporting that rtl_tcp and rtlamr had died and needed to be restarted:

```CRITICAL:RTL_TCP has died, trying to restart...```

This didn't make sense though because it would consistently happen once after every sleep cycle, and on second attempt at restarting, it would always be successful. Not too debilitating, basically means the add on would sleep for twice as long as it should.

I independently tried to figure out what was happening here and seemed like the subprocess instances in the `rtlamr` and `rtltcp` variables were still referencing the killed subprocess after the first call to `shutdown` was made ahead of a sleep cycle. When reiterating through the main loop after sleep was concluded, it would catch an error since those variables were still referring to killed processes, thinking there was some kind of error in those processes. Pretty easy fix then, set `rtlamr` and `rtltcp` to None after `shutdown` was called in the sleep loop. I've tested this on my system and seems to fix my issue.

Admittedly before doing all this I hadn't scrolled through the issues in this repo, and seems like this issue was already reported in #358 and maybe #328 as well. Also, @baudneo noted a similar fix in a comment on #358 (I think he might be working on some other changes with an async rewrite as well):
> If my code works for people, I will set up a PR. FWICT, it was an issue with free after use, `rtl_amr` and `rtl_tcp` were not being set to `None` after calling `shutdown()` but before re-iterating the loop which caused issues with termination and a hanging process.
> 
> I've had rtlamr2mqtt running for a good 20 hours straight with no missed readings. I think the issue is resolved.

At any rate, I figured I'd make a very simple PR to optimize handling of `rtlamr` and `rtltcp`. It's shown improvement on my system with more consistent reporting times given a value for `sleep_for`.

Thanks