### PR TITLE
Ensure rtlamr2mqtt sends a status set to online when HA is back

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -323,11 +323,14 @@ def main():
     while keep_reading:
         try:
             if mqtt_client.last_message is not None:
+                message_payload = mqtt_client.last_message.payload.decode()
                 if LOG_LEVEL >= 3:
                     logger.debug('Received MQTT message: %s on topic %s',
-                        mqtt_client.last_message.payload.decode(),
+                        message_payload,
                         mqtt_client.last_message.topic
                     )
+                # When Home Assistant comes back online, republish discovery and status
+                if message_payload == 'online':
                     for meter in config['meters']:
                         discovery_payload = ha_msgs.meter_discover_payload(config["mqtt"]["base_topic"], config['meters'][meter])
                         mqtt_client.publish(
@@ -336,6 +339,13 @@ def main():
                             qos=1,
                             retain=False
                         )
+                    # Republish online status so HA knows we're still here
+                    mqtt_client.publish(
+                        topic=f'{config["mqtt"]["base_topic"]}/status',
+                        payload='online',
+                        qos=1,
+                        retain=False
+                    )
                 mqtt_client.last_message = None
 
             # Start RTL_TCP if not remote


### PR DESCRIPTION
I was wondering why each time HA was restarted (or stopped), rtlamr2mqtt wasn't being seen anymore, unless I restart it again.

After troubleshooting it a bit, I saw the indentation of some the code to send back status was wrongly under a test regarding being in debug mode, and it was also missing a send regarding the status being online.

I made this commit to fix that.

Current behavior:
1. start rtlamr2mqtt and HA
2. restart HA
3. observe HA doesn't see anything online

With this patch:
1. start rtlamr2mqtt and HA
2. restart HA
3. HA can see sensors online after a delay (unsure why)

Here is a snippet of the log with the patched docker container 
```
[2025-11-01 14:18:55,764] DEBUG:Received MQTT message: online on topic homeassistant/status
[2025-11-01 14:18:55,764] INFO:Publishing to homeassistant/device/xxxx/config: {"device": {...
[2025-11-01 14:18:55,765] INFO:Publishing to homeassistant/device/xxxx/config: {"device": {...
[2025-11-01 14:18:55,765] INFO:Publishing to rtlamr/status: online
[2025-11-01 14:21:04,801] INFO:Publishing to rtlamr/status: online
```

Thanks,
Nicolas
