### PR TITLE
Fix false crash detection after intentional sleep shutdown

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -459,6 +459,11 @@ def main():
                     logger.info('Sleeping for %d seconds...', config["general"]["sleep_for"])
                 # Shutdown everything, but mqtt_client
                 shutdown(rtlamr=rtlamr, rtltcp=rtltcp, mqtt_client=None)
+                # Reset process references so the next loop iteration
+                # creates fresh processes instead of detecting the
+                # intentionally-terminated ones as crashed
+                rtlamr = None
+                rtltcp = None
                 read_counter = []
                 try:
                     sleep(int(config['general']['sleep_for']))

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -344,7 +344,7 @@ def main():
                     rtltcp = start_rtltcp(config)
                 if rtltcp is not None:
                     rtltcp.poll()
-                if rtltcp.returncode is not None:
+                if rtltcp is not None and rtltcp.returncode is not None:
                     if LOG_LEVEL >= 3:
                         logger.critical('RTL_TCP has died, trying to restart...')
                     rtltcp = start_rtltcp(config)


### PR DESCRIPTION
Fixes #382

## Problem

After `shutdown()` terminates `rtlamr` and `rtltcp` during the sleep cycle, the process variables still hold references to the dead `Popen` objects. On the next loop iteration, `poll()` detects a returncode and treats the intentional termination as an unexpected crash, triggering:

1. `CRITICAL: RTL_TCP has died` false alarm on every cycle
2. Unnecessary USB device reset via the crash-recovery path
3. `CRITICAL: RTLAMR has died` false alarm
4. An extra `sleep_for` delay (the crash-recovery path for rtlamr sleeps for `sleep_for` seconds before restarting, doubling the actual cycle time)

This makes the system fragile — the repeated crash-recovery path with USB resets can eventually fail to recover, leaving meter sensors permanently `unavailable`.

## Fix

Set `rtlamr` and `rtltcp` to `None` after the intentional `shutdown()` call, so the next loop iteration creates fresh processes via the normal startup path (`if rtltcp is None: rtltcp = start_rtltcp(config)`) instead of the crash-recovery path.

## Testing

Tested on a live Home Assistant instance with an RTL-SDR dongle and SCM electric meter. Before the fix, every cycle showed false `CRITICAL` crash messages and double-sleep. After the fix, clean startup every cycle with correct ~60s timing.