### PR TITLE
Only reset USB device on crash recovery, not on every startup

### DIFF
--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -459,6 +459,11 @@ def main():
                     logger.info('Sleeping for %d seconds...', config["general"]["sleep_for"])
                 # Shutdown everything, but mqtt_client
                 shutdown(rtlamr=rtlamr, rtltcp=rtltcp, mqtt_client=None)
+                # Reset process references so the next loop iteration
+                # creates fresh processes instead of detecting the
+                # intentionally-terminated ones as crashed
+                rtlamr = None
+                rtltcp = None
                 read_counter = []
                 try:
                     sleep(int(config['general']['sleep_for']))

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -93,7 +93,7 @@ def get_iso8601_timestamp():
 
 
 
-def start_rtltcp(config):
+def start_rtltcp(config, reset_usb=False):
     """ Start RTL_TCP process """
     # Check if we are using a remote RTL_TCP server
     is_remote = config["general"]["rtltcp_host"].split(':')[0] not in [ '127.0.0.1', 'localhost' ]
@@ -116,7 +116,7 @@ def start_rtltcp(config):
             return None
 
 
-    if 'RTLAMR2MQTT_USE_MOCK' not in dict(os.environ) and not is_remote:
+    if 'RTLAMR2MQTT_USE_MOCK' not in dict(os.environ) and not is_remote and reset_usb:
         if LOG_LEVEL >= 3:
             logger.debug('Reseting USB device: %s', usb_id)
         usbutil.reset_usb_device(usb_id)
@@ -347,7 +347,7 @@ def main():
                 if rtltcp.returncode is not None:
                     if LOG_LEVEL >= 3:
                         logger.critical('RTL_TCP has died, trying to restart...')
-                    rtltcp = start_rtltcp(config)
+                    rtltcp = start_rtltcp(config, reset_usb=True)
                     if rtltcp is not None:
                         rtltcp.poll()
                 if rtltcp is None:


### PR DESCRIPTION
Fixes #384

## Problem

`start_rtltcp()` unconditionally calls `reset_usb_device()` every time it starts rtl_tcp. With `sleep_for=60`, this results in ~1,440 USB resets per day during normal operation — even when the previous cycle completed cleanly.

The [Linux kernel documentation](https://www.kernel.org/doc/Documentation/driver-api/usb.rst) warns that frequent `USBDEVFS_RESET` calls can trigger driver and USB subsystem bugs, particularly with lower-quality USB devices like many RTL-SDR dongles, potentially destabilizing the USB connection over time.

## Fix

Add a `reset_usb` parameter (default `False`) to `start_rtltcp()`. The normal startup path passes the default (no reset), while the crash-recovery path passes `reset_usb=True` where a USB reset is actually needed to recover a stuck device.

## Testing

Tested on a live Home Assistant instance with an RTL-SDR dongle and SCM electric meter. Normal read cycles no longer perform a USB reset, while crash recovery still does.