### PR TITLE
feat: add device_serial option for RTL-SDR serial number selection

### DIFF
--- a/rtlamr2mqtt-addon/DOCS.md
+++ b/rtlamr2mqtt-addon/DOCS.md
@@ -68,10 +68,13 @@ general:
   sleep_for: 0
   # Verbose output. It can be: debug, info, warning, error, none
   verbosity: debug
-  # if you have multiple RTL devices, set the device id to use with this instance.
-  # Get the ID running the lsusb command. If not specified, the first device will be used.
-  # Example:
-  # device_id: '001:010'
+  # if you have multiple RTL devices, set the device to use with this instance.
+  # You can identify the device by USB bus:device address (from lsusb) or by
+  # serial number (programmed via rtl_eeprom). Serial numbers are recommended
+  # for multi-dongle setups as they remain stable across reboots.
+  # If neither is specified, the first device will be used.
+  # device_id: '001:010'        # USB bus:device address
+  # device_serial: '00000200'   # RTL-SDR serial number (set with rtl_eeprom -s 00000200)
   # RTL_TCP host and port to connect. Default, use the internal server
   # If you want to use a remote rtl_tcp server, set the host and port here
   # rtltcp_host: "172.17.0.4:1234"

--- a/rtlamr2mqtt-addon/app/helpers/buildcmd.py
+++ b/rtlamr2mqtt-addon/app/helpers/buildcmd.py
@@ -71,10 +71,16 @@ def build_rtltcp_args(config):
     custom_parameters = ''
     if 'rtltcp' in config['custom_parameters']:
         custom_parameters = config['custom_parameters']['rtltcp']
+    device_serial = config['general']['device_serial']
     device_id = config['general']['device_id']
-    if 'RTLAMR2MQTT_USE_MOCK' not in dict(environ):
-        sdl_devices = usbutils.find_rtl_sdr_devices()
-    dev_arg = '-d 0'
-    if device_id != '0' and device_id in sdl_devices:
-        dev_arg = f'-d {sdl_devices.index(device_id)}'
+    if device_serial:
+        # Serial number: pass directly to rtl_tcp (it supports -d <serial>)
+        dev_arg = f'-d {device_serial}'
+    else:
+        # Bus:device format or default '0': look up device index
+        if 'RTLAMR2MQTT_USE_MOCK' not in dict(environ):
+            sdl_devices = usbutils.find_rtl_sdr_devices()
+        dev_arg = '-d 0'
+        if device_id != '0' and device_id in sdl_devices:
+            dev_arg = f'-d {sdl_devices.index(device_id)}'
     return list(set([ custom_parameters, dev_arg]))

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -85,6 +85,7 @@ def load_config(config_path=None):
     general['sleep_for'] = int(general.get('sleep_for', 0))
     general['verbosity'] = str(general.get('verbosity', 'info'))
     general['device_id'] = str(general.get('device_id', '0'))
+    general['device_serial'] = str(general.get('device_serial', '')) if general.get('device_serial') else ''
     general['rtltcp_host'] = str(general.get('rtltcp_host', '127.0.0.1:1234'))
     # MQTT section
     mqtt['host'] = mqtt.get('host', None)

--- a/rtlamr2mqtt-addon/app/helpers/usb_utils.py
+++ b/rtlamr2mqtt-addon/app/helpers/usb_utils.py
@@ -40,6 +40,26 @@ def find_rtl_sdr_devices():
                 break
     return devices_found
 
+def find_bus_device_by_serial(serial):
+    """
+    Find the USB bus:device address for an RTL-SDR device with the given serial number.
+    Returns the bus:device string (e.g. '001:003') or None if not found.
+    """
+    sdl_file_path = os.path.join(os.path.dirname(__file__), 'sdl_ids.txt')
+    DEVICE_IDS = load_id_file(sdl_file_path)
+    for dev in usb.core.find(find_all=True):
+        for known_dev in DEVICE_IDS:
+            usb_id, usb_vendor = known_dev.split(':')
+            if dev.idVendor == int(usb_id, 16) and dev.idProduct == int(usb_vendor, 16):
+                try:
+                    dev_serial = dev.serial_number
+                except (usb.core.USBError, ValueError):
+                    dev_serial = None
+                if dev_serial == serial:
+                    return f'{dev.bus:03d}:{dev.address:03d}'
+                break
+    return None
+
 def reset_usb_device(usbdev):
     """
     Reset USB port

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -101,25 +101,40 @@ def start_rtltcp(config, reset_usb=False):
     if is_remote:
         return 'remote'
 
-    if 'RTLAMR2MQTT_USE_MOCK' in dict(os.environ) or is_remote:
-        usb_id_list = [ '001:001']
-    else:
-        # Search for RTL-SDR devices
-        usb_id_list = usbutil.find_rtl_sdr_devices()
+    device_serial = config['general']['device_serial']
 
-    usb_id = config['general']['device_id']
-    if config['general']['device_id'] == '0':
-        if len(usb_id_list) > 0:
-            usb_id = usb_id_list[0]
-        else:
-            logger.critical('No RTL-SDR devices found. Exiting...')
-            return None
-
-
-    if 'RTLAMR2MQTT_USE_MOCK' not in dict(os.environ) and not is_remote and reset_usb:
+    if device_serial:
+        # Serial number mode: resolve to bus:device for USB reset if needed
         if LOG_LEVEL >= 3:
-            logger.debug('Reseting USB device: %s', usb_id)
-        usbutil.reset_usb_device(usb_id)
+            logger.info('Using RTL-SDR device by serial number: %s', device_serial)
+        if 'RTLAMR2MQTT_USE_MOCK' not in dict(os.environ) and not is_remote and reset_usb:
+            bus_device = usbutil.find_bus_device_by_serial(device_serial)
+            if bus_device:
+                if LOG_LEVEL >= 3:
+                    logger.debug('Reseting USB device: %s (serial %s)', bus_device, device_serial)
+                usbutil.reset_usb_device(bus_device)
+            else:
+                logger.warning('Could not find USB device with serial %s for reset', device_serial)
+    else:
+        # Bus:device format or default '0'
+        if 'RTLAMR2MQTT_USE_MOCK' in dict(os.environ) or is_remote:
+            usb_id_list = [ '001:001']
+        else:
+            # Search for RTL-SDR devices
+            usb_id_list = usbutil.find_rtl_sdr_devices()
+
+        usb_id = config['general']['device_id']
+        if config['general']['device_id'] == '0':
+            if len(usb_id_list) > 0:
+                usb_id = usb_id_list[0]
+            else:
+                logger.critical('No RTL-SDR devices found. Exiting...')
+                return None
+
+        if 'RTLAMR2MQTT_USE_MOCK' not in dict(os.environ) and not is_remote and reset_usb:
+            if LOG_LEVEL >= 3:
+                logger.debug('Reseting USB device: %s', usb_id)
+            usbutil.reset_usb_device(usb_id)
 
     rtltcp_args = cmd.build_rtltcp_args(config)
     rtltcp_full_command = [which("rtl_tcp")] + rtltcp_args

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -41,6 +41,7 @@ schema:
     sleep_for: "int?"
     verbosity: "list(debug|info|warning|critical|none)?"
     device_id: "match(^[0-9]{3}:[0-9]{3})?"
+    device_serial: "str?"
     rtltcp_host: match(([\w\d\.]+):(\d+))?
   mqtt:
     host: "str?"


### PR DESCRIPTION
## Summary

Add a new `device_serial` configuration option that allows selecting an RTL-SDR device by its serial number (programmed via `rtl_eeprom`) instead of the USB bus:device address.

**Problem:** In multi-dongle setups, USB bus:device addresses change across reboots, breaking device selection (#347). The existing `device_id` field only accepts `NNN:NNN` format, and workarounds via `custom_parameters.rtltcp` cause duplicate `-d` flags (#337).

**Solution:** A new `device_serial` option that is explicit and separate from `device_id`:
- Passed directly to `rtl_tcp -d <serial>` (natively supported by rtl_tcp)
- For USB reset, the serial is dynamically resolved to the current bus:device address via pyusb at runtime — this addresses the maintainer's concern from #347 about USB resets needing bus:device addresses
- `device_id` keeps its strict `NNN:NNN` regex validation unchanged
- `device_serial` takes precedence when both are set

## Changes

| File | Change |
|------|--------|
| `config.yaml` | Add `device_serial: "str?"` to schema (existing `device_id` regex unchanged) |
| `config.py` | Load `device_serial` with empty string default |
| `usb_utils.py` | Add `find_bus_device_by_serial()` — resolves serial → bus:device for USB reset |
| `buildcmd.py` | When `device_serial` is set, pass it directly to `-d` flag |
| `rtlamr2mqtt.py` | Serial mode: skip USB enumeration, resolve serial→bus:device for reset |
| `DOCS.md` | Document `device_serial` with examples |

## USB reset support

The maintainer noted in #347 that USB resets require bus:device addresses. This PR handles that by resolving the serial number to the current bus:device address at runtime via `find_bus_device_by_serial()` before calling `reset_usb_device()`. This means USB resets work correctly even when bus:device addresses change across reboots.

## Backward compatibility

- `device_id` field validation and behavior is completely unchanged
- Default behavior (no options set, uses first device) is unchanged
- New `device_serial` option is fully optional

## Example configuration

```yaml
general:
  # Recommended: use serial number (stable across reboots)
  device_serial: '00000200'

  # Or continue using bus:device address (existing behavior)
  # device_id: '001:003'
```

## Test plan

- [ ] Verify existing `device_id` (NNN:NNN format) still works
- [ ] Verify default (neither set) still selects first device
- [ ] Verify `device_serial` selects correct dongle via `rtl_tcp -d <serial>`
- [ ] Verify USB reset works in serial mode (resolves serial → current bus:device)
- [ ] Verify multi-dongle setup survives reboot with serial-based config
- [ ] Verify `device_serial` takes precedence when both options are set

Closes #347
Relates to #337