### PR TITLE
fix: handle MqttError ExceptionGroup in publisher reconnect loop

### DIFF
--- a/rtlamr2mqtt-addon/app/mqtt_publisher.py
+++ b/rtlamr2mqtt-addon/app/mqtt_publisher.py
@@ -85,12 +85,33 @@ class MQTTPublisher:
                         except Exception:
                             pass
             except aiomqtt.MqttError as e:
+                # Direct MqttError — e.g. initial connection failure, broker
+                # unreachable. aiomqtt.Client().__aenter__() raises this
+                # before _run_connected is even called.
                 if self.shutdown_event.is_set():
                     break
                 logger.warning('MQTT connection lost: %s. Reconnecting in 5s...', e)
                 await asyncio.sleep(5)
-            except asyncio.CancelledError:
-                break
+            except BaseException as e:
+                # _run_connected uses a TaskGroup whose subtasks can raise
+                # MqttError when the broker drops mid-session. The TaskGroup
+                # wraps these in an ExceptionGroup — a distinct type that
+                # does NOT match `except MqttError` above (ExceptionGroup
+                # contains MqttError but is not a subclass of it).
+                if isinstance(e, asyncio.CancelledError):
+                    break
+                if isinstance(e, ExceptionGroup) and any(
+                    isinstance(sub, aiomqtt.MqttError) for sub in e.exceptions
+                ):
+                    if self.shutdown_event.is_set():
+                        break
+                    logger.warning(
+                        'MQTT connection lost (via TaskGroup): %s. Reconnecting in 5s...',
+                        e.exceptions[0],
+                    )
+                    await asyncio.sleep(5)
+                    continue
+                raise
 
         logger.info('MQTT publisher shutting down')
 

--- a/rtlamr2mqtt-addon/tests/test_mqtt_publisher.py
+++ b/rtlamr2mqtt-addon/tests/test_mqtt_publisher.py
@@ -81,6 +81,75 @@ class TestMQTTPublisherReadings:
                 break
 
 
+class _FakeClient:
+    """Async context manager that behaves like aiomqtt.Client but doesn't
+    connect to a real broker. Properly propagates exceptions (unlike
+    AsyncMock, whose __aexit__ returns a truthy mock and swallows them)."""
+
+    async def __aenter__(self):
+        return AsyncMock()  # stands in for the connected client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False  # never suppress exceptions
+
+
+class TestMQTTPublisherReconnect:
+    async def test_run_survives_mqtt_exception_group(self, sample_config):
+        """Publisher.run() must not crash when _run_connected raises
+        ExceptionGroup wrapping MqttError.
+
+        Reproduces the production crash from 2026-04-14:
+            ERROR: Task error: unhandled errors in a TaskGroup (1 sub-exception)
+            INFO: Goodbye!
+
+        Without the fix, the ExceptionGroup propagates out of run() because
+        `except aiomqtt.MqttError` doesn't match ExceptionGroup. With the
+        fix, it's caught and run() reconnects.
+        """
+        import aiomqtt
+
+        queue = asyncio.Queue()
+        shutdown = asyncio.Event()
+        pub = MQTTPublisher(
+            config=sample_config,
+            reading_queue=queue,
+            shutdown_event=shutdown,
+        )
+
+        call_count = 0
+        original_run_connected = pub._run_connected
+
+        async def fake_run_connected(client):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Simulate the ExceptionGroup that TaskGroup produces
+                # when both subtasks hit MqttError on broker disconnect
+                raise ExceptionGroup(
+                    "unhandled errors in a TaskGroup",
+                    [aiomqtt.MqttError("Connection lost")],
+                )
+            # Second call: shut down cleanly so run() exits
+            shutdown.set()
+
+        pub._run_connected = fake_run_connected
+
+        with patch('mqtt_publisher.aiomqtt.Client', return_value=_FakeClient()):
+            with patch('mqtt_publisher.aiomqtt.Will'):
+                try:
+                    await asyncio.wait_for(pub.run(), timeout=10.0)
+                except (ExceptionGroup, Exception) as e:
+                    pytest.fail(
+                        f"run() crashed with {type(e).__name__}: {e}\n"
+                        "The MqttError ExceptionGroup was not caught by the "
+                        "reconnection loop."
+                    )
+
+        assert call_count == 2, (
+            f"Expected 2 connection attempts (crash + reconnect), got {call_count}"
+        )
+
+
 class TestMQTTPublisherStatus:
     async def test_publish_online(self, publisher):
         mock_client = AsyncMock()


### PR DESCRIPTION
## Problem

When the MQTT broker restarts (e.g. Mosquitto addon upgrade on HA), the publisher's inner `TaskGroup` in `_run_connected()` (line 107) wraps the `MqttError` from its subtasks in an `ExceptionGroup`. The reconnection loop's `except aiomqtt.MqttError` on line 87 doesn't match `ExceptionGroup`, so the exception propagates up to `main()`'s `TaskGroup`, killing the addon.

### Production crash log (after Mosquitto upgrade)

```
[14:09:28] INFO: Sleeping for 300 seconds
[14:12:35] ERROR: Task error: unhandled errors in a TaskGroup (1 sub-exception)
[14:12:35] INFO: Shutting down...
[14:12:35] INFO: Goodbye!
```

The addon exited cleanly and didn't restart (watchdog wasn't enabled), leaving meter sensors permanently `unavailable` until manual intervention ~1.5 days later.

## Root Cause

`_run_connected()` uses a nested `TaskGroup` with two subtasks (`_listen_ha_status` and `_consume_readings`). When MQTT drops, both subtasks raise `MqttError`. Python's `TaskGroup` wraps these in an `ExceptionGroup`, which doesn't match the existing `except aiomqtt.MqttError` handler.

## Fix

Add a `except BaseException` handler after the existing `except MqttError` that inspects `ExceptionGroup` instances for wrapped `MqttError` exceptions. If found, treat as a reconnectable MQTT disconnection (same 5s backoff). Otherwise re-raise.

## Test

The new test calls `publisher.run()` with a mock that raises `ExceptionGroup(MqttError)` — the exact exception a `TaskGroup` produces when subtasks hit MQTT errors.

- **Without the fix**: test fails — `run()` crashes with the `ExceptionGroup` propagating out
- **With the fix**: test passes — `run()` catches it and reconnects

All 78 tests pass.