### PR TITLE
chore: bump to v2026.4.21 with HA discovery fixes and CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,20 @@ on:
     branches:
       - main
       - dev
+      - async
     tags:
       - "*.*.*"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.json"
+      - "**.yaml"
+      - "LICENSE"
+      - "examples/**"
+    branches:
+      - main
+      - dev
+      - async
 
 concurrency:
   group: "build-${{ github.ref }}"
@@ -26,14 +38,32 @@ env:
   IMAGE_NAME: rtlamr2mqtt
 
 jobs:
-  release:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        working-directory: rtlamr2mqtt-addon
+        run: pip install -r requirements-dev.txt
+      - name: Run tests
+        working-directory: rtlamr2mqtt-addon
+        run: pytest -v
+
+  release:
+    needs: tests
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -45,22 +75,22 @@ jobs:
             type=sha
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: "amd64,arm64,arm/v7,arm/v6"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: rtlamr2mqtt-addon/
           platforms: linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+### 2026.4.21
+
+- Periodic HA discovery re-publish to recover from simultaneous broker/HA restarts (configurable via `mqtt.discovery_interval`, default 300s)
+- Fixed `sw_version` in HA device discovery payload to reflect actual add-on version
+- Fixed `device_class: none` in add-on schema — field is now optional; omit it instead of using `none`
+- Fixed `unit_of_measurement` capitalisation for energy meters (`KWh` → `kWh`)
+
 ### 2026.3.26
 
 - Major rewrite of the codebase to improve maintainability and performance assisted by AI agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**rtlamr2mqtt** bridges RTL-SDR radio receivers to MQTT, enabling Home Assistant to read utility meters (electric, gas, water). It runs either as a **Home Assistant add-on** or a **standalone Docker container**. The v2026 rewrite replaced blocking subprocess calls with a fully async architecture.
+
+All application code lives under `rtlamr2mqtt-addon/` — this is both the Docker build context and the HA add-on root.
+
+## Commands
+
+All commands run from `rtlamr2mqtt-addon/`:
+
+```bash
+# Set up dev environment
+python3 -m venv .venv
+.venv/bin/pip install -r requirements-dev.txt
+
+# Run all tests
+.venv/bin/pytest
+
+# Run a single test file
+.venv/bin/pytest tests/test_process_manager.py -v
+
+# Run a single test by name
+.venv/bin/pytest tests/test_config.py -v -k "test_load_standalone"
+
+# Lint
+.venv/bin/pylint --rcfile=.pylint app/
+
+# Build Docker image (standalone mode)
+docker build -t rtlamr2mqtt .
+
+# Integration test with mock RTL-SDR hardware
+docker compose up --build
+# In another terminal, subscribe to verify output:
+docker exec rtlamr2mqtt-addon-mosquitto-1 mosquitto_sub -t 'rtlamr/#' -t 'homeassistant/#' -v
+```
+
+**pytest config:** `asyncio_mode = auto` — all async test functions run automatically without explicit markers.
+
+## Architecture
+
+### Dual-Mode Execution
+
+The single codebase detects its runtime at startup via the `SUPERVISOR_TOKEN` environment variable:
+
+- **HA add-on mode**: Config is read from `/data/options.json` (or `.yaml`). The MQTT broker is auto-discovered by calling `http://supervisor/services/mqtt` with the supervisor token. No MQTT credentials needed in config.
+- **Standalone Docker mode**: Full config is read from `/etc/rtlamr2mqtt.yaml` (or a path passed as `sys.argv[1]`). All MQTT settings must be present in the config file.
+
+Detection happens in [helpers/config.py](rtlamr2mqtt-addon/app/helpers/config.py) — `os.getenv("SUPERVISOR_TOKEN")` determines which path runs.
+
+### Async Task Pipeline
+
+```
+asyncio.TaskGroup
+├── MeterReader (reads rtlamr stdout → asyncio.Queue)
+└── MQTTPublisher (drains queue → publishes to MQTT)
+```
+
+The two main classes communicate through a shared `asyncio.Queue(maxsize=100)` and a shared `asyncio.Event` (shutdown signal). They are both started as tasks in a `TaskGroup` in [rtlamr2mqtt.py](rtlamr2mqtt-addon/app/rtlamr2mqtt.py).
+
+Signal handlers (`SIGTERM`, `SIGINT`) call `shutdown_event.set()`, which both tasks watch on every iteration.
+
+### Process Lifecycle (ManagedProcess)
+
+[process_manager.py](rtlamr2mqtt-addon/app/process_manager.py) wraps two external processes:
+
+- **rtl_tcp** — talks to the RTL-SDR USB hardware
+- **rtlamr** — decodes meter broadcasts from rtl_tcp's stream
+
+Key behaviors:
+- Prepends `stdbuf -oL` to force line-buffered stdout (avoids hangs waiting for output)
+- `start_with_retry()` retries up to 5 times with `[2, 5, 10, 20, 30]` second backoff; calls an optional `on_retry` callback between attempts (used for USB reset)
+- `stop()` sends SIGTERM to the **process group** (`start_new_session=True`), then SIGKILL after 2s
+- If `rtltcp_host` points to a remote host (not `127.0.0.1`/`localhost`), rtl_tcp is not started locally and USB management is skipped
+
+### Sleep/Wake Cycle
+
+When `sleep_for > 0`, after all configured meters are seen, [meter_reader.py](rtlamr2mqtt-addon/app/meter_reader.py):
+1. Stops rtlamr and rtl_tcp
+2. Sleeps for `sleep_for` seconds (interruptible by shutdown)
+3. Restarts rtl_tcp, then calls `tickle_rtl_tcp()` (sends frequency-change commands via raw TCP to wake up stuck receivers)
+4. Restarts rtlamr
+5. Begins reading again
+
+### MQTT Publisher
+
+[mqtt_publisher.py](rtlamr2mqtt-addon/app/mqtt_publisher.py) uses `aiomqtt` (async wrapper over paho-mqtt v2):
+- Sets an LWT (Last Will and Testament) to publish `offline` on unexpected disconnect
+- On connection: publishes all HA discovery payloads, subscribes to `homeassistant/status`
+- When HA publishes `online` to that topic (HA restart), re-publishes all discovery payloads
+- Inner `TaskGroup` runs `_listen_ha_status` and `_consume_readings` concurrently
+- On `MqttError` or `ExceptionGroup` containing `MqttError`: reconnects with 5s backoff
+
+### Configuration Shape
+
+After loading, `config` is a dict with these top-level keys: `general`, `mqtt`, `meters`, `custom_parameters`. The `meters` value is a dict keyed by **string** meter ID. See [helpers/config.py](rtlamr2mqtt-addon/app/helpers/config.py) for all fields and defaults.
+
+### rtlamr Output Parsing
+
+[helpers/read_output.py](rtlamr2mqtt-addon/app/helpers/read_output.py) parses JSON lines from rtlamr. Different meter protocols use different field names:
+- Meter ID: tries `EndpointID`, then `ERTSerialNumber`, then `ID`
+- Consumption: tries `Consumption`, then `LastConsumptionCount`, then `LastConsumption`
+
+### MQTT Topics
+
+```
+{base_topic}/status                          → "online" / "offline" (LWT)
+{base_topic}/{meter_id}/state                → {"reading": "001234.567", "lastseen": "..."}
+{base_topic}/{meter_id}/attributes           → protocol-specific raw fields
+homeassistant/device/{meter_id}/config       → HA MQTT discovery payload
+```
+
+## Code Style
+
+Pylint enforces these (see [.pylint](rtlamr2mqtt-addon/.pylint)):
+- Max line length: 100 characters
+- Logging uses `%`-style format strings (not f-strings) — `logger.warning('msg %s', var)` not `logger.warning(f'msg {var}')`
+- No docstrings required (`missing-function-docstring` disabled)
+- PascalCase for classes, snake_case everywhere else
+
+## Testing Notes
+
+- `conftest.py` provides `sample_config`, `sample_rtlamr_scm_line`, `sample_rtlamr_idm_line`, `sample_rtlamr_r900_line` fixtures
+- The `mock/` directory contains shell scripts that simulate `rtlamr` and `rtl_tcp` for integration tests
+- Integration tests use `docker-compose.yaml` with a real Mosquitto broker and the mock binaries
+
+## Versioning
+
+Uses date-based versioning (`YYYY.M.D`). Version is defined in [helpers/info.py](rtlamr2mqtt-addon/app/helpers/info.py) and mirrored in [config.yaml](rtlamr2mqtt-addon/config.yaml).

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -104,6 +104,7 @@ def load_config(config_path=None):
     mqtt['base_topic'] = str(mqtt.get('base_topic', 'rtlamr'))
     mqtt['ha_status_topic'] = str(mqtt.get('ha_status_topic', 'homeassistant/status'))
     mqtt['ha_autodiscovery_topic'] = mqtt.get('ha_autodiscovery_topic', 'homeassistant')
+    mqtt['discovery_interval'] = int(mqtt.get('discovery_interval', 300))
 
     # Custom parameters section (defaults like -s 2048000 and -unique=true
     # are applied in buildcmd.py only when not overridden here)

--- a/rtlamr2mqtt-addon/app/helpers/ha_messages.py
+++ b/rtlamr2mqtt-addon/app/helpers/ha_messages.py
@@ -35,7 +35,7 @@ def meter_discover_payload(base_topic, meter_config):
             'name': meter_name,
             'manufacturer': meter_config.get('manufacturer', 'RTLAMR2MQTT'),
             'model': meter_config.get('model', 'Smart Meter'),
-            'sw_version': '1.0',
+            'sw_version': i.version(),
             'serial_number': meter_id,
             'hw_version': '1.0',
         },

--- a/rtlamr2mqtt-addon/app/helpers/info.py
+++ b/rtlamr2mqtt-addon/app/helpers/info.py
@@ -6,7 +6,7 @@ def version():
     """
     Returns the version of the application.
     """
-    return '2026.3.26'
+    return '2026.4.21'
 
 def origin_url():
     """

--- a/rtlamr2mqtt-addon/app/mqtt_publisher.py
+++ b/rtlamr2mqtt-addon/app/mqtt_publisher.py
@@ -37,6 +37,7 @@ class MQTTPublisher:
         self.base_topic = mqtt_config['base_topic']
         self.ha_status_topic = mqtt_config['ha_status_topic']
         self.ha_autodiscovery_topic = mqtt_config['ha_autodiscovery_topic']
+        self.discovery_interval = mqtt_config['discovery_interval']
         self.meters = config['meters']
         self.reading_queue = reading_queue
         self.shutdown_event = shutdown_event
@@ -124,10 +125,11 @@ class MQTTPublisher:
         await self.publish_status(client, 'online')
         await client.subscribe(self.ha_status_topic, qos=1)
 
-        # Run HA status listener and reading consumer concurrently
+        # Run HA status listener, reading consumer, and periodic discovery concurrently
         async with asyncio.TaskGroup() as tg:
             tg.create_task(self._listen_ha_status(client))
             tg.create_task(self._consume_readings(client))
+            tg.create_task(self._periodic_discovery(client, self.discovery_interval))
 
     async def _listen_ha_status(self, client: aiomqtt.Client):
         """
@@ -220,6 +222,25 @@ class MQTTPublisher:
         )
 
         logger.info('Published reading for meter %s: %s', meter_id, formatted)
+
+    async def _periodic_discovery(self, client: aiomqtt.Client, interval: int = 300):
+        """
+        Re-publish HA discovery payloads every `interval` seconds.
+        Covers the race condition where HA and the broker restart simultaneously
+        and rtlamr2mqtt misses the homeassistant/status = online message.
+        """
+        while not self.shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self.shutdown_event.wait(),
+                    timeout=interval,
+                )
+                break
+            except asyncio.TimeoutError:
+                pass
+            if not self.shutdown_event.is_set():
+                logger.debug('Periodic re-publish of HA discovery payloads')
+                await self.publish_discovery(client)
 
     async def publish_status(self, client, status: str):
         """

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: rtlamr2mqtt
-version: 2026.3.26
+version: 2026.4.21
 slug: rtlamr2mqtt
 panel_icon: mdi:gauge
 description: RTLAMR to MQTT Bridge
@@ -28,12 +28,13 @@ options:
     ha_autodiscovery_topic: homeassistant
     ha_status_topic: homeassistant/status
     base_topic: "rtlamr"
+    discovery_interval: 300
   meters:
     - id: 22222222
       protocol: r900
       name: my_energy_meter
       format: "######.###"
-      # device_class on HA
+      unit_of_measurement: "kWh"
       device_class: energy
 
 schema:
@@ -41,12 +42,12 @@ schema:
     sleep_for: "int?"
     verbosity: "list(debug|info|warning|critical|none)?"
     device_id: "int?"
-    rtltcp_host: match(([\w\d\.]+):(\d+))?
+    rtltcp_host: "str?"
   mqtt:
     host: "str?"
     port: "int?"
     user: "str?"
-    password: str?
+    password: "str?"
     tls_enabled: "bool?"
     tls_insecure: "bool?"
     tls_ca: "str?"
@@ -55,6 +56,7 @@ schema:
     ha_autodiscovery_topic: "str?"
     ha_status_topic: "str?"
     base_topic: "str?"
+    discovery_interval: "int?"
   custom_parameters:
     rtltcp: "str?"
     rtlamr: "str?"
@@ -65,7 +67,7 @@ schema:
       format: "str?"
       unit_of_measurement: "str?"
       icon: "str?"
-      device_class: list(none|current|energy|gas|power|water)
+      device_class: list(current|energy|gas|power|water)?
       state_class: list(measurement|total|total_increasing)?
       expire_after: int?
       force_update: bool?

--- a/rtlamr2mqtt-addon/test-config.yaml
+++ b/rtlamr2mqtt-addon/test-config.yaml
@@ -22,6 +22,6 @@ meters:
     protocol: r900
     name: my_energy_meter
     format: "######.###"
-    unit_of_measurement: "KWh"
+    unit_of_measurement: "kWh"
     icon: mdi:gauge
     device_class: energy

--- a/rtlamr2mqtt-addon/tests/conftest.py
+++ b/rtlamr2mqtt-addon/tests/conftest.py
@@ -29,6 +29,7 @@ def sample_config():
             'base_topic': 'rtlamr',
             'ha_status_topic': 'homeassistant/status',
             'ha_autodiscovery_topic': 'homeassistant',
+            'discovery_interval': 300,
         },
         'custom_parameters': {
             'rtltcp': '',
@@ -50,7 +51,7 @@ def sample_config():
                 'protocol': 'r900',
                 'name': 'my_energy_meter',
                 'format': '######.###',
-                'unit_of_measurement': 'KWh',
+                'unit_of_measurement': 'kWh',
                 'icon': 'mdi:gauge',
                 'device_class': 'energy',
                 'state_class': 'total_increasing',


### PR DESCRIPTION
## Summary

- **Periodic HA discovery re-publish**: re-publishes discovery payloads every N seconds (configurable via `mqtt.discovery_interval`, default 300s) to recover from simultaneous broker/HA restarts without needing `retain=true`
- **Fixed `sw_version`** in HA device discovery payload — was hardcoded to `"1.0"`, now reflects the actual add-on version via `i.version()`
- **Fixed `device_class` schema** — removed invalid `none` value and made the field optional; users should omit it rather than set it to `none`
- **Fixed `unit_of_measurement` capitalisation** in energy meter examples (`KWh` → `kWh`) to match HA's Energy dashboard expectations
- **Added `CLAUDE.md`** with codebase guidance for Claude Code
- **CI improvements**: added pytest job (blocks Docker build on test failure), added `pull_request` trigger, added `async` branch, updated all GitHub Actions to latest major versions

## Test plan

- [x] Verify tests pass in CI on this PR
- [x] Deploy to HA add-on and confirm device version shows `2026.4.21` in HA device info
- [x] Confirm energy meter sensor appears in HA Energy dashboard with correct unit
- [x] Restart HA while add-on is running and confirm entities reappear within `discovery_interval` seconds
- [x] Confirm omitting `device_class` from a meter config works without errors
