### PR TITLE
feat: add listen mode for meter discovery without MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ It works by running [rtl_tcp](https://osmocom.org/projects/rtl-sdr/wiki/Rtl-sdr)
 > This version is a complete rewrite of the application internals. \
 > Your old entities should be cleaned manually from your MQTT broker.
 
-> [!CAUTION]
-> This version does **not** have the LISTEN MODE. \
-> It is planned, but not implemented yet.
-
 ### Changes from the previous version
 
 - **Async subprocess management** -- Replaced blocking `subprocess.Popen` with `asyncio.create_subprocess_exec`. The application no longer hangs when rtl_tcp or rtlamr stall, which was a recurring issue on resource-constrained devices like Raspberry Pi.
@@ -42,7 +38,9 @@ It works by running [rtl_tcp](https://osmocom.org/projects/rtl-sdr/wiki/Rtl-sdr)
 - **Standard Python logging** -- Replaced the custom numeric log level system with Python's built-in `logging` module. No more `if LOG_LEVEL >= 3:` checks scattered throughout the code.
 - **Replaced `unbuffer` with `stdbuf`** -- Removed the dependency on the `expect` package. Line-buffered subprocess output now uses `stdbuf -oL` from coreutils.
 - **HA discovery re-publish** -- When Home Assistant restarts, discovery messages are automatically re-published. This was previously broken (gated behind a log level check).
-- **Test coverage** -- Added 70 unit and integration tests using pytest and pytest-asyncio.
+- **Listen mode** -- New `general.listen_mode: true` option. Runs without any meter filter and logs every meter it hears, deduplicated per session. No MQTT connection is made. Useful for discovering your meter ID before configuring the add-on.
+- **Periodic HA discovery re-publish** -- Discovery payloads are re-sent on a configurable interval (`mqtt.discovery_interval`, default 300 s) in addition to on HA restart, so entities survive MQTT broker restarts even with `retain=false`.
+- **Test coverage** -- Added 90 unit tests using pytest and pytest-asyncio.
 - **Dual-purpose Dockerfile** -- Works both as a Home Assistant add-on (with `BUILD_FROM`) and as a standalone Docker container (defaults to `python:3.13-slim`).
 - **Bug fixes** -- Fixed: non-deterministic meter ID key lookup, undefined variable in mock mode, deprecated paho-mqtt API usage, USB file descriptor leak in reset, hardcoded TLS 1.2 protocol.
 
@@ -94,6 +92,56 @@ services:
       - /path/to/rtlamr2mqtt.yaml:/etc/rtlamr2mqtt.yaml:ro
 ```
 
+## Finding Your Meter ID (Listen Mode)
+
+If you don't know your meter ID, use **listen mode** to discover it. In this mode rtlamr2mqtt runs without any meter filter, logs every meter it receives, and makes no MQTT connection.
+
+### Home Assistant Add-On
+
+In the add-on configuration, set:
+
+```yaml
+general:
+  listen_mode: true
+```
+
+Leave the `meters` list empty (or remove it entirely). Start the add-on and open the **Log** tab. You will see a warning followed by one log line per discovered meter:
+
+```
+WARNING: LISTEN MODE ACTIVE — no meter filtering, no MQTT publishing. Check logs for "New meter" lines to discover your meter ID, then configure it and disable listen_mode.
+
+INFO: New meter | ID: 12345678 | Type: SCM  | Consumption: 1978226
+INFO: New meter | ID: 87654321 | Type: R900 | Consumption: 4555831
+```
+
+Each meter is logged **once per session** regardless of how many times it broadcasts. Note the **ID** and **Type** for the meter you want to track, then configure it normally and set `listen_mode: false`.
+
+### Docker / Standalone
+
+Create a minimal config file:
+
+```yaml
+general:
+  listen_mode: true
+  verbosity: info
+
+mqtt:
+  host: 127.0.0.1   # still required for standalone, but no connection is made
+```
+
+Run the container and watch the logs:
+
+```bash
+docker run --rm \
+  -v /path/to/listen.yaml:/etc/rtlamr2mqtt.yaml:ro \
+  --device /dev/bus/usb:/dev/bus/usb \
+  allangood/rtlamr2mqtt
+```
+
+Once you have found your meter ID, update your config with the full meter definition and set `listen_mode: false` (or remove the line — `false` is the default).
+
+---
+
 ## Configuration
 
 When running standalone (not as an HA add-on), create a `rtlamr2mqtt.yaml` file. Below is a complete example with all available options:
@@ -109,6 +157,8 @@ general:
   # RTL_TCP server address. Default: local server at 127.0.0.1:1234
   # Set to a remote address to use an external rtl_tcp instance.
   # rtltcp_host: "192.168.1.100:1234"
+  # Enable to log all received meters without MQTT. Useful for finding your meter ID.
+  # listen_mode: false
 
 mqtt:
   # MQTT broker connection (not needed when running as HA add-on)
@@ -126,6 +176,8 @@ mqtt:
   ha_autodiscovery_topic: homeassistant
   ha_status_topic: homeassistant/status
   base_topic: rtlamr
+  # How often (seconds) to re-publish HA discovery payloads. Keeps entities alive after broker restarts.
+  # discovery_interval: 300
 
 # Optional: pass extra arguments to rtl_tcp or rtlamr
 # custom_parameters:
@@ -158,6 +210,7 @@ meters:
 | `verbosity` | string | `info` | Log level: `debug`, `info`, `warning`, `error`, `critical`, `none` |
 | `device_id` | int | `0` | RTL-SDR device index. `0` = first device found. |
 | `rtltcp_host` | string | `127.0.0.1:1234` | RTL_TCP server address. Set to remote host to skip local rtl_tcp. |
+| `listen_mode` | bool | `false` | Log all received meters without filtering. No MQTT connection. See [Finding Your Meter ID](#finding-your-meter-id-listen-mode). |
 
 #### mqtt
 
@@ -175,6 +228,7 @@ meters:
 | `ha_autodiscovery_topic` | string | `homeassistant` | HA MQTT auto-discovery prefix. |
 | `ha_status_topic` | string | `homeassistant/status` | Topic to monitor HA restarts. |
 | `base_topic` | string | `rtlamr` | Base topic for status and readings. |
+| `discovery_interval` | int | `300` | Seconds between periodic HA discovery re-publishes. |
 
 #### meters[]
 

--- a/rtlamr2mqtt-addon/app/helpers/buildcmd.py
+++ b/rtlamr2mqtt-addon/app/helpers/buildcmd.py
@@ -51,13 +51,10 @@ def build_rtlamr_args(config):
 
     args.extend(custom_args)
 
-    # Meter IDs filter
-    ids = ','.join(list(meters.keys()))
-    args.append(f'-filterid={ids}')
-
-    # Message types
-    msgtypes = get_comma_separated_str('protocol', meters)
-    args.append(f'-msgtype={msgtypes}')
+    # Meter IDs filter and message types (omitted in listen mode when meters is empty)
+    if meters:
+        args.append(f'-filterid={",".join(meters.keys())}')
+        args.append(f'-msgtype={get_comma_separated_str("protocol", meters)}')
 
     return args
 

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -72,19 +72,23 @@ def load_config(config_path=None):
     else:
         return ('error', 'Config file format not supported.', None)
 
-    if 'meters' not in config:
-        return ('error', 'No meters section found in config file.', None)
-
     # Parse sections with defaults
     general = config.get('general') or {}
     mqtt = config.get('mqtt') or {}
     custom_parameters = config.get('custom_parameters') or {}
 
     # General section
+    general['listen_mode'] = bool(general.get('listen_mode', False))
     general['sleep_for'] = int(general.get('sleep_for', 0))
     general['verbosity'] = str(general.get('verbosity', 'info'))
     general['device_id'] = int(general.get('device_id', 0))
     general['rtltcp_host'] = str(general.get('rtltcp_host', '127.0.0.1:1234'))
+
+    if 'meters' not in config and not general['listen_mode']:
+        return ('error', 'No meters section found in config file.', None)
+
+    if general['listen_mode']:
+        general['sleep_for'] = 0
 
     # MQTT section
     mqtt['host'] = mqtt.get('host', None)
@@ -118,7 +122,7 @@ def load_config(config_path=None):
         'icon', 'device_class', 'state_class', 'expire_after',
         'force_update', 'manufacturer', 'model',
     ]
-    for m in config['meters']:
+    for m in config.get('meters') or []:
         m['state_class'] = m.get('state_class', 'total_increasing')
         meters[str(m['id'])] = {key: value for key, value in m.items() if key in meters_allowed_keys}
 

--- a/rtlamr2mqtt-addon/app/helpers/read_output.py
+++ b/rtlamr2mqtt-addon/app/helpers/read_output.py
@@ -64,7 +64,7 @@ def get_message_for_ids(rtlamr_output, meter_ids_list):
         return None
 
     meter_id = str(message[meter_id_key])
-    if meter_id not in meter_ids_list:
+    if meter_ids_list and meter_id not in meter_ids_list:
         return None
 
     message.pop(meter_id_key)
@@ -74,4 +74,9 @@ def get_message_for_ids(rtlamr_output, meter_ids_list):
         return None
 
     consumption = message.pop(consumption_key)
-    return {'meter_id': meter_id, 'consumption': int(consumption), 'message': message}
+    return {
+        'meter_id': meter_id,
+        'consumption': int(consumption),
+        'msg_type': json_output.get('Type', 'unknown'),
+        'message': message,
+    }

--- a/rtlamr2mqtt-addon/app/meter_reader.py
+++ b/rtlamr2mqtt-addon/app/meter_reader.py
@@ -36,6 +36,8 @@ class MeterReader:
         self.meter_ids = list(config['meters'].keys())
         self.sleep_for = config['general']['sleep_for']
         self.rtltcp_host = config['general']['rtltcp_host']
+        self.listen_mode = config['general']['listen_mode']
+        self._seen_ids: set = set()
 
     async def run(self):
         """
@@ -73,20 +75,30 @@ class MeterReader:
                 if reading is None:
                     continue
 
-                # Enqueue the reading
-                try:
-                    self.reading_queue.put_nowait(reading)
-                except asyncio.QueueFull:
-                    # Drop oldest reading to make room
-                    try:
-                        self.reading_queue.get_nowait()
-                    except asyncio.QueueEmpty:
-                        pass
-                    self.reading_queue.put_nowait(reading)
-                    logger.warning('Reading queue full, dropped oldest reading')
+                meter_id = reading['meter_id']
 
-                meters_seen.add(reading['meter_id'])
-                logger.debug('Meter %s reading: %s', reading['meter_id'], reading['consumption'])
+                if self.listen_mode:
+                    if meter_id not in self._seen_ids:
+                        self._seen_ids.add(meter_id)
+                        logger.info(
+                            'New meter | ID: %s | Type: %s | Consumption: %s',
+                            meter_id, reading['msg_type'], reading['consumption'],
+                        )
+                else:
+                    # Enqueue the reading
+                    try:
+                        self.reading_queue.put_nowait(reading)
+                    except asyncio.QueueFull:
+                        # Drop oldest reading to make room
+                        try:
+                            self.reading_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            pass
+                        self.reading_queue.put_nowait(reading)
+                        logger.warning('Reading queue full, dropped oldest reading')
+
+                meters_seen.add(meter_id)
+                logger.debug('Meter %s reading: %s', meter_id, reading['consumption'])
 
                 # Check if all meters have been read (sleep_for mode)
                 if self.sleep_for > 0 and meters_seen == set(self.meter_ids):

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -63,6 +63,12 @@ def load_and_validate_config():
     setup_logging(config['general']['verbosity'])
     logger.info('Starting rtlamr2mqtt %s', i.version())
     logger.info(msg)
+    if config['general']['listen_mode']:
+        logger.warning(
+            'LISTEN MODE ACTIVE — no meter filtering, no MQTT publishing. '
+            'Check logs for "New meter" lines to discover your meter ID, '
+            'then configure it and disable listen_mode.'
+        )
     return config
 
 
@@ -71,7 +77,8 @@ async def main():
     config = load_and_validate_config()
 
     shutdown_event = asyncio.Event()
-    reading_queue = asyncio.Queue(maxsize=100)
+    listen_mode = config['general']['listen_mode']
+    reading_queue = None if listen_mode else asyncio.Queue(maxsize=100)
 
     # Signal handlers
     loop = asyncio.get_event_loop()
@@ -148,7 +155,7 @@ async def main():
             await rtltcp_proc.stop()
         sys.exit(1)
 
-    # Create reader and publisher
+    # Create reader (and publisher when not in listen mode)
     reader = MeterReader(
         config=config,
         rtlamr=rtlamr_proc,
@@ -158,17 +165,19 @@ async def main():
         is_remote=is_remote,
     )
 
-    publisher = MQTTPublisher(
-        config=config,
-        reading_queue=reading_queue,
-        shutdown_event=shutdown_event,
-    )
-
-    # Run reader and publisher concurrently
     try:
-        async with asyncio.TaskGroup() as tg:
-            tg.create_task(reader.run())
-            tg.create_task(publisher.run())
+        if listen_mode:
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(reader.run())
+        else:
+            publisher = MQTTPublisher(
+                config=config,
+                reading_queue=reading_queue,
+                shutdown_event=shutdown_event,
+            )
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(reader.run())
+                tg.create_task(publisher.run())
     except* Exception as eg:
         for exc in eg.exceptions:
             if not isinstance(exc, asyncio.CancelledError):

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -23,6 +23,7 @@ options:
   general:
     sleep_for: 60
     verbosity: info
+    listen_mode: false
   custom_parameters: {}
   mqtt:
     ha_autodiscovery_topic: homeassistant
@@ -43,6 +44,7 @@ schema:
     verbosity: "list(debug|info|warning|critical|none)?"
     device_id: "int?"
     rtltcp_host: "str?"
+    listen_mode: "bool?"
   mqtt:
     host: "str?"
     port: "int?"
@@ -60,7 +62,7 @@ schema:
   custom_parameters:
     rtltcp: "str?"
     rtlamr: "str?"
-  meters:
+  meters?:
     - id: int
       protocol: list(idm|netidm|r900|r900bcd|scm|scm+)
       name: "str"

--- a/rtlamr2mqtt-addon/tests/conftest.py
+++ b/rtlamr2mqtt-addon/tests/conftest.py
@@ -15,6 +15,7 @@ def sample_config():
             'verbosity': 'info',
             'device_id': 0,
             'rtltcp_host': '127.0.0.1:1234',
+            'listen_mode': False,
         },
         'mqtt': {
             'host': '127.0.0.1',

--- a/rtlamr2mqtt-addon/tests/test_buildcmd.py
+++ b/rtlamr2mqtt-addon/tests/test_buildcmd.py
@@ -50,6 +50,24 @@ class TestBuildRtlamrArgs:
         assert server_args[0] == '-server=127.0.0.1:1234'
 
 
+class TestBuildRtlamrArgsListenMode:
+    def test_no_filterid_when_no_meters(self, sample_config):
+        sample_config['meters'] = {}
+        args = build_rtlamr_args(sample_config)
+        assert not any(a.startswith('-filterid=') for a in args)
+
+    def test_no_msgtype_when_no_meters(self, sample_config):
+        sample_config['meters'] = {}
+        args = build_rtlamr_args(sample_config)
+        assert not any(a.startswith('-msgtype=') for a in args)
+
+    def test_format_and_server_still_present_in_listen_mode(self, sample_config):
+        sample_config['meters'] = {}
+        args = build_rtlamr_args(sample_config)
+        assert '-format=json' in args
+        assert '-server=127.0.0.1:1234' in args
+
+
 class TestBuildRtltcpArgs:
     def test_local_basic(self, sample_config):
         args = build_rtltcp_args(sample_config)

--- a/rtlamr2mqtt-addon/tests/test_config.py
+++ b/rtlamr2mqtt-addon/tests/test_config.py
@@ -124,6 +124,35 @@ class TestLoadConfig:
         finally:
             os.unlink(path)
 
+    def test_listen_mode_default_is_false(self):
+        path = write_temp_yaml(MINIMAL_YAML)
+        try:
+            status, msg, config = load_config(path)
+            assert status == 'success'
+            assert config['general']['listen_mode'] is False
+        finally:
+            os.unlink(path)
+
+    def test_listen_mode_no_meters_required(self):
+        content = "general:\n  listen_mode: true\nmqtt:\n  host: 127.0.0.1\n"
+        path = write_temp_yaml(content)
+        try:
+            status, msg, config = load_config(path)
+            assert status == 'success'
+            assert config['general']['listen_mode'] is True
+        finally:
+            os.unlink(path)
+
+    def test_listen_mode_forces_sleep_for_zero(self):
+        content = "general:\n  listen_mode: true\n  sleep_for: 60\nmqtt:\n  host: 127.0.0.1\n"
+        path = write_temp_yaml(content)
+        try:
+            status, msg, config = load_config(path)
+            assert status == 'success'
+            assert config['general']['sleep_for'] == 0
+        finally:
+            os.unlink(path)
+
     def test_device_id_as_integer(self):
         content = """
 general:

--- a/rtlamr2mqtt-addon/tests/test_meter_reader.py
+++ b/rtlamr2mqtt-addon/tests/test_meter_reader.py
@@ -130,6 +130,79 @@ class TestMeterReaderSleepCycle:
         assert queue.qsize() == 2
 
 
+class TestMeterReaderListenMode:
+    @pytest.fixture
+    def listen_reader(self, sample_config, mock_rtlamr, mock_rtltcp):
+        sample_config['general']['listen_mode'] = True
+        sample_config['meters'] = {}
+        shutdown = asyncio.Event()
+        return MeterReader(
+            config=sample_config,
+            rtlamr=mock_rtlamr,
+            rtltcp=mock_rtltcp,
+            reading_queue=None,
+            shutdown_event=shutdown,
+            is_remote=False,
+        )
+
+    async def test_listen_mode_logs_not_enqueues(self, listen_reader, mock_rtlamr, sample_rtlamr_scm_line, caplog):
+        """In listen mode, readings should be logged but never put on a queue."""
+        import logging
+        call_count = 0
+        async def fake_read_line():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return sample_rtlamr_scm_line
+            listen_reader.shutdown_event.set()
+            return None
+        mock_rtlamr.read_line = fake_read_line
+
+        with caplog.at_level(logging.INFO, logger='rtlamr2mqtt'):
+            await listen_reader.run()
+
+        assert any('33333333' in r.message for r in caplog.records)
+        assert listen_reader.reading_queue is None
+
+    async def test_listen_mode_deduplication(self, listen_reader, mock_rtlamr, sample_rtlamr_scm_line, caplog):
+        """The same meter ID should only be logged once per session."""
+        import logging
+        call_count = 0
+        async def fake_read_line():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return sample_rtlamr_scm_line  # same line twice
+            listen_reader.shutdown_event.set()
+            return None
+        mock_rtlamr.read_line = fake_read_line
+
+        with caplog.at_level(logging.INFO, logger='rtlamr2mqtt'):
+            await listen_reader.run()
+
+        new_meter_logs = [r for r in caplog.records if '33333333' in r.message]
+        assert len(new_meter_logs) == 1
+
+    async def test_listen_mode_accepts_unknown_meter(self, listen_reader, mock_rtlamr, caplog):
+        """In listen mode, meters not in config should still be logged."""
+        import logging
+        unknown_line = '{"Time":"2025-05-05T21:25:10Z","Offset":0,"Length":0,"Type":"R900","Message":{"ID":9999999,"Unkn1":163,"NoUse":0,"BackFlow":0,"Consumption":100,"Unkn3":0,"Leak":0,"LeakNow":0}}'
+        call_count = 0
+        async def fake_read_line():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return unknown_line
+            listen_reader.shutdown_event.set()
+            return None
+        mock_rtlamr.read_line = fake_read_line
+
+        with caplog.at_level(logging.INFO, logger='rtlamr2mqtt'):
+            await listen_reader.run()
+
+        assert any('9999999' in r.message for r in caplog.records)
+
+
 class TestMeterReaderProcessRestart:
     async def test_restart_on_rtlamr_death(self, reader, mock_rtlamr):
         """If rtlamr dies (read_line returns None), it should be restarted."""

--- a/rtlamr2mqtt-addon/tests/test_read_output.py
+++ b/rtlamr2mqtt-addon/tests/test_read_output.py
@@ -64,3 +64,20 @@ class TestGetMessageForIds:
     def test_non_json_string(self):
         result = get_message_for_ids('GainCount: 29', ['33333333'])
         assert result is None
+
+    def test_empty_ids_list_accepts_any_meter(self, sample_rtlamr_scm_line):
+        """Empty meter_ids_list (listen mode) should return readings for any meter ID."""
+        result = get_message_for_ids(sample_rtlamr_scm_line, [])
+        assert result is not None
+        assert result['meter_id'] == '33333333'
+
+    def test_msg_type_in_result(self, sample_rtlamr_scm_line):
+        result = get_message_for_ids(sample_rtlamr_scm_line, ['33333333'])
+        assert result is not None
+        assert result['msg_type'] == 'SCM'
+
+    def test_msg_type_defaults_to_unknown(self):
+        line = '{"Offset":0,"Length":0,"Message":{"ID":12345,"Consumption":100}}'
+        result = get_message_for_ids(line, ['12345'])
+        assert result is not None
+        assert result['msg_type'] == 'unknown'


### PR DESCRIPTION
## Summary

Adds a **listen mode** sniffer feature for users who don't yet know their meter ID.

- New config flag: `general.listen_mode: true` (default `false`)
- When enabled, rtlamr runs without any `-filterid` or `-msgtype` filter, accepting all broadcasts
- Each newly-discovered meter is logged **once per session**: `New meter | ID: 12345678 | Type: SCM | Consumption: 1234567`
- **No MQTT connection is made** — no queue, no publisher, log output only
- `sleep_for` is forced to 0 in listen mode (sleep/wake cycle doesn't apply)
- `meters:` section in config becomes optional when `listen_mode: true`
- A prominent `WARNING` is logged on startup when listen mode is active

## How to use

```yaml
general:
  listen_mode: true
mqtt:
  host: 127.0.0.1
```

Check the logs for `New meter` lines, note the meter ID and protocol type, then configure normally and set `listen_mode: false`.

## Changes

- `helpers/config.py` — parse `listen_mode`, skip meters-required check, force `sleep_for=0`
- `helpers/buildcmd.py` — skip `-filterid`/`-msgtype` args when meters dict is empty
- `helpers/read_output.py` — accept all meter IDs when list is empty; add `msg_type` to returned dict
- `meter_reader.py` — log directly in listen mode with per-session deduplication; skip queue
- `rtlamr2mqtt.py` — skip queue/publisher creation in listen mode; log startup warning
- `config.yaml` — add `listen_mode` option, make `meters?` optional in schema

## Tests

11 new tests across 4 files; all 90 tests pass.

- `TestBuildRtlamrArgsListenMode` — no filterid/msgtype when meters empty
- `TestLoadConfig` — listen mode loads without meters, forces sleep_for=0, defaults to false
- `TestGetMessageForIds` — empty ID list accepts any meter, msg_type in result
- `TestMeterReaderListenMode` — logs not enqueues, deduplication, unknown meters accepted