### PR TITLE
fix: replace invalid meters?: schema key with meters: [] default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 2026.4.22
+
+- Added **listen mode** (`general.listen_mode: true`) to discover meter IDs without connecting to MQTT; logs each new meter once per session
+- Fixed invalid `meters?:` schema syntax — HA Supervisor only supports `?` on scalar types. Default options now use `meters: []` and an empty meters list in non-listen mode returns a clear error
+
 ### 2026.4.21
 
 - Periodic HA discovery re-publish to recover from simultaneous broker/HA restarts (configurable via `mqtt.discovery_interval`, default 300s)

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -84,8 +84,8 @@ def load_config(config_path=None):
     general['device_id'] = int(general.get('device_id', 0))
     general['rtltcp_host'] = str(general.get('rtltcp_host', '127.0.0.1:1234'))
 
-    if 'meters' not in config and not general['listen_mode']:
-        return ('error', 'No meters section found in config file.', None)
+    if not (config.get('meters') or []) and not general['listen_mode']:
+        return ('error', 'No meters configured. Add at least one meter or enable listen_mode to discover meter IDs.', None)
 
     if general['listen_mode']:
         general['sleep_for'] = 0

--- a/rtlamr2mqtt-addon/app/helpers/info.py
+++ b/rtlamr2mqtt-addon/app/helpers/info.py
@@ -6,7 +6,7 @@ def version():
     """
     Returns the version of the application.
     """
-    return '2026.4.21'
+    return '2026.4.22'
 
 def origin_url():
     """

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -30,13 +30,7 @@ options:
     ha_status_topic: homeassistant/status
     base_topic: "rtlamr"
     discovery_interval: 300
-  meters:
-    - id: 22222222
-      protocol: r900
-      name: my_energy_meter
-      format: "######.###"
-      unit_of_measurement: "kWh"
-      device_class: energy
+  meters: []
 
 schema:
   general:
@@ -62,7 +56,7 @@ schema:
   custom_parameters:
     rtltcp: "str?"
     rtlamr: "str?"
-  meters?:
+  meters:
     - id: int
       protocol: list(idm|netidm|r900|r900bcd|scm|scm+)
       name: "str"

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: rtlamr2mqtt
-version: 2026.4.21
+version: 2026.4.22
 slug: rtlamr2mqtt
 panel_icon: mdi:gauge
 description: RTLAMR to MQTT Bridge

--- a/rtlamr2mqtt-addon/tests/test_config.py
+++ b/rtlamr2mqtt-addon/tests/test_config.py
@@ -124,6 +124,14 @@ class TestLoadConfig:
         finally:
             os.unlink(path)
 
+    def test_empty_meters_list_without_listen_mode_fails(self):
+        path = write_temp_yaml("mqtt:\n  host: 127.0.0.1\nmeters: []\n")
+        try:
+            status, msg, config = load_config(path)
+            assert status == 'error'
+        finally:
+            os.unlink(path)
+
     def test_listen_mode_default_is_false(self):
         path = write_temp_yaml(MINIMAL_YAML)
         try:


### PR DESCRIPTION
## Summary

The `meters?:` key syntax in `config.yaml` is invalid — Home Assistant Supervisor only supports the `?` optional marker on scalar types (`str?`, `int?`, `bool?`), not on list-section keys.

**Fix:**
- `config.yaml`: change `meters?:` → `meters:` in schema; change the default options from an example meter to `meters: []` (empty list is now the default)
- `config.py`: tighten the guard from `'meters' not in config` to `not (config.get('meters') or [])` so an empty `meters: []` in non-listen mode is also rejected with a clear error message
- `test_config.py`: add test that `meters: []` without `listen_mode: true` returns an error

## Test plan

- [ ] 91 tests pass (`pytest -v`)
- [ ] HA add-on installs cleanly with no meters configured (listen mode)
- [ ] HA add-on with `meters: []` and no `listen_mode` shows a config error

🤖 Generated with [Claude Code](https://claude.com/claude-code)