### PR TITLE
feat: process diagnostics and USB recovery improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,20 @@
 {
   "name": "Example devcontainer for apps repositories",
-  "image": "ghcr.io/home-assistant/devcontainer:3-apps",
-  "appPort": [
-    "7123:8123",
-    "7357:4357"
-  ],
+  "image": "ghcr.io/home-assistant/devcontainer:5-apps",
+  "overrideCommand": false,
+  "remoteUser": "vscode",
+  "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
-  "runArgs": [
-    "-e",
-    "GIT_EDITOR=code --wait",
-    "--privileged"
-  ],
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
-    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+    "SUPERVISOR_CHANNEL": "beta"
   },
   "customizations": {
     "vscode": {
-      "extensions": [
-        "timonwong.shellcheck",
-        "esbenp.prettier-vscode"
-      ],
+      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
       "settings": {
         "terminal.integrated.profiles.linux": {
           "zsh": {
@@ -38,6 +31,8 @@
   },
   "mounts": [
     "type=volume,target=/var/lib/docker",
-    "type=volume,target=/mnt/supervisor"
+    "type=volume,target=/var/lib/containerd",
+    "type=volume,target=/mnt/supervisor",
+    "type=tmpfs,target=/tmp"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,31 @@
 # CHANGELOG
 
+### 2026.5.1
+
+- Added stuck-process diagnostics to `ManagedProcess`: rolling 20-line stdout buffer, `exit_code` and `recent_output` properties, and a dump of recent output on startup timeout, early exit during ready-wait, and runtime exit — failure logs now include what the process actually printed instead of a bare timeout message (failure modes proposed by [@crash0verride11](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52))
+- Capped the post-SIGKILL `wait()` at 5 seconds to prevent an indefinite hang when a process is stuck in kernel D-state on USB I/O (Synology-class issue) (proposed by [@crash0verride11](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52))
+- Made `tickle_rtl_tcp` async — replaces blocking `socket` + `time.sleep` calls with `asyncio.open_connection`, so the MQTT publisher and shutdown handler no longer stall during a tickle. Writer is closed in a `finally` so partial-write failures don't leak file descriptors (proposed by [@crash0verride11](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52))
+- When rtlamr exits, restart rtl_tcp first if it also died — closes a gap where rtlamr's restart attempts would all hit `connection refused` after a shared USB error took both processes down together (proposed by [@crash0verride11](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52))
+- Fixed rtlamr readiness check broken by upstream v0.9.5 slog migration — `ready_pattern` changed from `GainCount:` to `GainCount` to match both old (`GainCount: 29`) and new (`GainCount=29`) log formats, eliminating the 30s timeout-and-kill on every start (#404 by Adam Light)
+- Pinned rtlamr to v0.9.5 in the Dockerfile (was `@latest`) to prevent future breakage from upstream changes (#404 by Adam Light)
+- Updated mock `rtlamr` script and process-manager tests to match the slog output format (#404 by Adam Light)
+- Added a water-leak-detection automation example to the README (utility_meter + derivative sensor for overnight and sustained-flow patterns) (#403 by @allangood)
+
 ### 2026.4.22
 
-- Added **listen mode** (`general.listen_mode: true`) to discover meter IDs without connecting to MQTT; logs each new meter once per session
-- Fixed invalid `meters?:` schema syntax — HA Supervisor only supports `?` on scalar types. Default options now use `meters: []` and an empty meters list in non-listen mode returns a clear error
+- Added **listen mode** (`general.listen_mode: true`) to discover meter IDs without connecting to MQTT; logs each new meter once per session (#399 by @allangood)
+- Fixed invalid `meters?:` schema syntax — HA Supervisor only supports `?` on scalar types. Default options now use `meters: []` and an empty meters list in non-listen mode returns a clear error (#402 by @allangood)
 
 ### 2026.4.21
 
-- Periodic HA discovery re-publish to recover from simultaneous broker/HA restarts (configurable via `mqtt.discovery_interval`, default 300s)
-- Fixed `sw_version` in HA device discovery payload to reflect actual add-on version
-- Fixed `device_class: none` in add-on schema — field is now optional; omit it instead of using `none`
-- Fixed `unit_of_measurement` capitalisation for energy meters (`KWh` → `kWh`)
+- Periodic HA discovery re-publish to recover from simultaneous broker/HA restarts (configurable via `mqtt.discovery_interval`, default 300s) (#397 by @allangood)
+- Fixed `sw_version` in HA device discovery payload to reflect actual add-on version (#397 by @allangood)
+- Fixed `device_class: none` in add-on schema — field is now optional; omit it instead of using `none` (#397 by @allangood)
+- Fixed `unit_of_measurement` capitalisation for energy meters (`KWh` → `kWh`) (#397 by @allangood)
+- Fixed publisher reconnect loop to handle `MqttError` wrapped in an `ExceptionGroup` by the inner `TaskGroup` — previously, an MQTT broker restart (e.g. Mosquitto upgrade) would crash the add-on instead of triggering a reconnect (#396 by @trionnis)
 
 ### 2026.3.26
 
-- Major rewrite of the codebase to improve maintainability and performance assisted by AI agent
-- Using AsyncIO to deal with subprocess calls in a non-blocking way
-- Using Async MQTT and Paho v2
+- Major rewrite of the codebase to improve maintainability and performance assisted by AI agent (by @allangood)
+- Using AsyncIO to deal with subprocess calls in a non-blocking way (by @allangood)
+- Using Async MQTT and Paho v2 (by @allangood)

--- a/rtlamr2mqtt-addon/app/helpers/info.py
+++ b/rtlamr2mqtt-addon/app/helpers/info.py
@@ -6,7 +6,7 @@ def version():
     """
     Returns the version of the application.
     """
-    return '2026.4.22'
+    return '2026.5.1'
 
 def origin_url():
     """

--- a/rtlamr2mqtt-addon/app/helpers/usb_utils.py
+++ b/rtlamr2mqtt-addon/app/helpers/usb_utils.py
@@ -2,13 +2,12 @@
 Helper functions for USB handling
 """
 
+import asyncio
 import os
 import re
-import socket
 import logging
 from random import randrange
 from struct import pack
-from time import sleep
 import usb.core
 
 logger = logging.getLogger('rtlamr2mqtt')
@@ -73,7 +72,7 @@ def reset_usb_device(device_index):
         return False
 
 
-def tickle_rtl_tcp(remote_server):
+async def tickle_rtl_tcp(remote_server):
     """
     Connect to rtl_tcp and change some tuner settings. This has proven to
     reset some receivers that are blocked and producing errors.
@@ -85,14 +84,23 @@ def tickle_rtl_tcp(remote_server):
     remote_host = parts[0]
     remote_port = int(parts[1]) if len(parts) > 1 else 1234
 
-    conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    conn.settimeout(5)
-    send_cmd = lambda c, command, parameter: c.send(pack(">BI", int(command), int(parameter)))
+    writer = None
     try:
-        conn.connect((remote_host, remote_port))
-        send_cmd(conn, SET_FREQUENCY, 88e6 + randrange(0, 20) * 1e6)
-        sleep(0.2)
-        send_cmd(conn, SET_SAMPLERATE, 2048000)
-    except socket.error as err:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(remote_host, remote_port),
+            timeout=5.0,
+        )
+        writer.write(pack(">BI", SET_FREQUENCY, int(88e6 + randrange(0, 20) * 1e6)))
+        await writer.drain()
+        await asyncio.sleep(0.2)
+        writer.write(pack(">BI", SET_SAMPLERATE, 2048000))
+        await writer.drain()
+    except (OSError, asyncio.TimeoutError) as err:
         logger.debug('Could not tickle rtl_tcp at %s: %s', remote_server, err)
-    conn.close()
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass

--- a/rtlamr2mqtt-addon/app/meter_reader.py
+++ b/rtlamr2mqtt-addon/app/meter_reader.py
@@ -56,7 +56,23 @@ class MeterReader:
                     if self.shutdown_event.is_set():
                         break
                     if not self.rtlamr.is_alive:
-                        logger.warning('rtlamr process died, attempting restart')
+                        logger.warning(
+                            'rtlamr process died (exit code: %s), attempting restart',
+                            self.rtlamr.exit_code,
+                        )
+                        if self.rtlamr.recent_output:
+                            logger.warning(
+                                'rtlamr last output before exit:\n  %s',
+                                '\n  '.join(self.rtlamr.recent_output),
+                            )
+                        # If rtl_tcp also died (e.g. shared USB error), restart it first
+                        # so rtlamr's reconnect attempts have something to talk to.
+                        if not self.is_remote and not self.rtltcp.is_alive:
+                            logger.warning('rtl_tcp also died, restarting it first')
+                            if not await self.rtltcp.start_with_retry():
+                                logger.error('Failed to restart rtl_tcp, shutting down')
+                                self.shutdown_event.set()
+                                return
                         if not await self.rtlamr.start_with_retry():
                             logger.error('Failed to restart rtlamr, shutting down')
                             self.shutdown_event.set()
@@ -151,7 +167,7 @@ class MeterReader:
                 return
 
         # Tickle rtl_tcp to wake up the receiver
-        usbutil.tickle_rtl_tcp(self.rtltcp_host)
+        await usbutil.tickle_rtl_tcp(self.rtltcp_host)
 
         # Restart rtlamr
         if not await self.rtlamr.start_with_retry():

--- a/rtlamr2mqtt-addon/app/process_manager.py
+++ b/rtlamr2mqtt-addon/app/process_manager.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import signal
 import logging
+from collections import deque
 from typing import Callable
 from shutil import which
 
@@ -43,10 +44,19 @@ class ManagedProcess:
         self.backoff = backoff if backoff is not None else [2, 5, 10, 20, 30]
         self.on_retry = on_retry
         self._process: asyncio.subprocess.Process | None = None
+        self._recent_lines: deque = deque(maxlen=20)
 
     @property
     def is_alive(self) -> bool:
         return self._process is not None and self._process.returncode is None
+
+    @property
+    def exit_code(self) -> int | None:
+        return self._process.returncode if self._process is not None else None
+
+    @property
+    def recent_output(self) -> list[str]:
+        return list(self._recent_lines)
 
     async def start(self) -> bool:
         """
@@ -63,6 +73,7 @@ class ManagedProcess:
 
         logger.info('Starting %s: %s', self.name, ' '.join(full_command))
 
+        self._recent_lines.clear()
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *full_command,
@@ -85,7 +96,11 @@ class ManagedProcess:
                 logger.info('%s is ready', self.name)
             return ready
         except asyncio.TimeoutError:
-            logger.error('%s did not become ready within %.1fs', self.name, self.ready_timeout)
+            logger.error(
+                '%s did not become ready within %.1fs (waiting for %r)',
+                self.name, self.ready_timeout, self.ready_pattern,
+            )
+            self._log_recent_output('last output before timeout')
             await self.stop()
             return False
 
@@ -102,13 +117,21 @@ class ManagedProcess:
                 # EOF — process exited
                 logger.error('%s exited before becoming ready (exit code: %s)',
                              self.name, self._process.returncode)
+                self._log_recent_output('last output before exit')
                 return False
 
             line = line_bytes.decode('utf-8', errors='replace').strip()
             if line:
+                self._recent_lines.append(line)
                 logger.debug('%s: %s', self.name, line)
             if self.ready_pattern in line:
                 return True
+
+    def _log_recent_output(self, label: str) -> None:
+        if self._recent_lines:
+            logger.error('%s %s:\n  %s', self.name, label, '\n  '.join(self._recent_lines))
+        else:
+            logger.error('%s produced no output', self.name)
 
     async def stop(self):
         """
@@ -135,7 +158,16 @@ class ManagedProcess:
                     os.killpg(self._process.pid, signal.SIGKILL)
                 except (ProcessLookupError, BrokenPipeError):
                     self._process.kill()
-                await self._process.wait()
+                # A process stuck in kernel D-state (uninterruptible USB I/O) ignores
+                # SIGKILL until the kernel releases it. Cap the wait so we don't hang.
+                try:
+                    await asyncio.wait_for(self._process.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    logger.error(
+                        '%s did not die after SIGKILL — likely stuck in kernel D-state. '
+                        'Continuing shutdown.',
+                        self.name,
+                    )
         except (ProcessLookupError, BrokenPipeError):
             pass  # Already dead
 
@@ -193,7 +225,10 @@ class ManagedProcess:
             # EOF
             return None
 
-        return line_bytes.decode('utf-8', errors='replace').strip()
+        line = line_bytes.decode('utf-8', errors='replace').strip()
+        if line:
+            self._recent_lines.append(line)
+        return line
 
     async def wait_for_exit(self):
         """

--- a/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
+++ b/rtlamr2mqtt-addon/app/rtlamr2mqtt.py
@@ -146,7 +146,7 @@ async def main():
             sys.exit(1)
 
     # Tickle rtl_tcp to wake it up
-    usbutil.tickle_rtl_tcp(rtltcp_host)
+    await usbutil.tickle_rtl_tcp(rtltcp_host)
 
     # Start rtlamr
     if not await rtlamr_proc.start_with_retry():

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: rtlamr2mqtt
-version: 2026.4.22
+version: 2026.5.1
 slug: rtlamr2mqtt
 panel_icon: mdi:gauge
 description: RTLAMR to MQTT Bridge

--- a/rtlamr2mqtt-addon/tests/test_usb_utils.py
+++ b/rtlamr2mqtt-addon/tests/test_usb_utils.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 from helpers.usb_utils import load_id_file, find_rtl_sdr_devices, get_device_by_index, tickle_rtl_tcp
 
 
@@ -71,20 +71,21 @@ class TestGetDeviceByIndex:
 
 
 class TestTickleRtlTcp:
-    @patch('helpers.usb_utils.socket.socket')
-    def test_tickle_sends_commands(self, mock_socket_class):
-        mock_conn = MagicMock()
-        mock_socket_class.return_value = mock_conn
-        tickle_rtl_tcp('127.0.0.1:1234')
-        mock_conn.connect.assert_called_once()
-        assert mock_conn.send.call_count == 2
-        mock_conn.close.assert_called_once()
+    @patch('helpers.usb_utils.asyncio.open_connection', new_callable=AsyncMock)
+    async def test_tickle_sends_commands(self, mock_open_connection):
+        mock_writer = MagicMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_open_connection.return_value = (MagicMock(), mock_writer)
 
-    @patch('helpers.usb_utils.socket.socket')
-    def test_tickle_handles_connection_error(self, mock_socket_class):
-        mock_conn = MagicMock()
-        mock_conn.connect.side_effect = ConnectionRefusedError("refused")
-        mock_socket_class.return_value = mock_conn
-        # Should not raise
-        tickle_rtl_tcp('127.0.0.1:1234')
-        mock_conn.close.assert_called_once()
+        await tickle_rtl_tcp('127.0.0.1:1234')
+
+        mock_open_connection.assert_called_once()
+        assert mock_writer.write.call_count == 2
+        mock_writer.close.assert_called_once()
+
+    @patch('helpers.usb_utils.asyncio.open_connection', new_callable=AsyncMock)
+    async def test_tickle_handles_connection_error(self, mock_open_connection):
+        mock_open_connection.side_effect = ConnectionRefusedError("refused")
+        # Should not raise — connection failure before writer is assigned
+        await tickle_rtl_tcp('127.0.0.1:1234')


### PR DESCRIPTION
## Summary
Four targeted reliability and diagnostic fixes inspired by the failure-mode analysis in [@crash0verride11's commit](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52). Each one rests on a deterministic signal — no inference, no false-positive surface.

- **Process diagnostics in `ManagedProcess`** — rolling 20-line stdout buffer, `exit_code`/`recent_output` properties, dumped on startup timeout, early ready-wait exit, and runtime exit. Failure logs now include what the process printed instead of a bare timeout message.
- **Post-SIGKILL D-state cap** — `wait()` after SIGKILL is now bounded at 5s with a clear error log, preventing the observed indefinite hang when a USB stall locks the process in kernel uninterruptible sleep.
- **Async `tickle_rtl_tcp`** — replaces blocking `socket` + `time.sleep` with `asyncio.open_connection`, so the MQTT publisher and shutdown handler no longer stall during a tickle. Writer is closed in `finally` to prevent FD leaks on partial-write failures.
- **rtl_tcp liveness check on rtlamr death** — when rtlamr exits and rtl_tcp also went down (e.g. shared USB error), restart rtl_tcp before retrying rtlamr. Closes a gap where the 5 retry attempts would all hit `connection refused`.

Skipped from the upstream proposal:
- 10-minute stdout watchdog — wrong signal; meters with low duty cycle would trigger spurious restarts
- Wake-attempt retry loop in `_sleep_cycle` — premise (tickle deterministically kills rtl_tcp) is shaky for stock rtl_tcp; the `is_alive` check above covers the cases that actually happen
- SIGTERM grace 2s→5s — pure tuning, unclear value

Also bumps version to 2026.5.1 and brings the dev container to v5-apps with extra mounts.

## Test plan
- [ ] `cd rtlamr2mqtt-addon && .venv/bin/pytest -q` (existing tests should pass; AsyncMock fixtures auto-resolve the new properties)
- [ ] `docker compose up --build` and verify rtlamr/rtl_tcp restart behavior with mock binaries
- [ ] On real hardware: confirm startup-timeout logs now include rtlamr's last output
- [ ] On real hardware: confirm shutdown completes within ~10s even when rtl_tcp can't be SIGKILL'd
