### PR TITLE
fix: HA discovery race + online status after periodic re-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 2026.5.3
+
+- Added a 2-second delay between receiving `homeassistant/status = online` and re-publishing discovery payloads. HA fires `online` slightly before its discovery handler is fully ready, causing payloads to be silently dropped and entities to stay `unavailable` after a restart
+- Periodic discovery re-publish now also publishes the `online` status afterwards, matching the connect and HA-restart paths
+
 ### 2026.5.1
 
 - Added stuck-process diagnostics to `ManagedProcess`: rolling 20-line stdout buffer, `exit_code` and `recent_output` properties, and a dump of recent output on startup timeout, early exit during ready-wait, and runtime exit — failure logs now include what the process actually printed instead of a bare timeout message (failure modes proposed by [@crash0verride11](https://github.com/crash0verride11/rtlamr2mqtt/commit/f29ecc108971cf589b50c7454a933b98b5841a52))

--- a/rtlamr2mqtt-addon/app/helpers/info.py
+++ b/rtlamr2mqtt-addon/app/helpers/info.py
@@ -6,7 +6,7 @@ def version():
     """
     Returns the version of the application.
     """
-    return '2026.5.1'
+    return '2026.5.3'
 
 def origin_url():
     """

--- a/rtlamr2mqtt-addon/app/mqtt_publisher.py
+++ b/rtlamr2mqtt-addon/app/mqtt_publisher.py
@@ -151,6 +151,10 @@ class MQTTPublisher:
                 payload = message.payload.decode('utf-8', errors='replace')
                 logger.info('HA status: %s', payload)
                 if payload == 'online':
+                    # HA fires `online` before its discovery handler is fully
+                    # ready; without a small delay the payload is silently
+                    # dropped and entities stay unavailable.
+                    await asyncio.sleep(2)
                     await self.publish_discovery(client)
                     await self.publish_status(client, 'online')
 
@@ -241,6 +245,7 @@ class MQTTPublisher:
             if not self.shutdown_event.is_set():
                 logger.debug('Periodic re-publish of HA discovery payloads')
                 await self.publish_discovery(client)
+                await self.publish_status(client, 'online')
 
     async def publish_status(self, client, status: str):
         """

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: rtlamr2mqtt
-version: 2026.5.1
+version: 2026.5.3
 slug: rtlamr2mqtt
 panel_icon: mdi:gauge
 description: RTLAMR to MQTT Bridge


### PR DESCRIPTION
## Summary

Two related fixes to ensure entities reappear in Home Assistant after a restart:

1. **2-second delay after `homeassistant/status = online`** before re-publishing discovery. HA fires the `online` status slightly before its MQTT discovery handler is fully wired up, so the discovery payload was silently dropped and entities stayed `unavailable` until the next periodic re-publish (or forever, depending on timing).
2. **Publish `online` status after each periodic discovery re-publish.** The connect and HA-restart paths both publish discovery + online, but the periodic path was missing the online step. Now all three paths follow the same pattern.

Bumps version to **2026.5.3** and adds a CHANGELOG entry.

## Test plan

- [x] All 9 mqtt_publisher tests pass
- [ ] In a real HA instance: restart HA and confirm entities transition from `unavailable` → reading values within ~3s, instead of staying `unavailable`
- [ ] Wait one full `discovery_interval` (default 300s) and confirm `homeassistant/device/.../config` is re-published followed by `rtlamr/status = online`

🤖 Generated with [Claude Code](https://claude.com/claude-code)