### PR TITLE
fix: listen mode now listens for all protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 2026.5.9
+
+- Fixed listen mode to actually listen for **all** protocols. rtlamr defaults to `scm` only when `-msgtype` is omitted, so listen mode was silently missing scm+, idm, netidm, r900, and r900bcd meters. Now passes `-msgtype=all` when no meters are configured
+
 ### 2026.5.3
 
 - Added a 2-second delay between receiving `homeassistant/status = online` and re-publishing discovery payloads. HA fires `online` slightly before its discovery handler is fully ready, causing payloads to be silently dropped and entities to stay `unavailable` after a restart

--- a/rtlamr2mqtt-addon/app/helpers/buildcmd.py
+++ b/rtlamr2mqtt-addon/app/helpers/buildcmd.py
@@ -51,10 +51,14 @@ def build_rtlamr_args(config):
 
     args.extend(custom_args)
 
-    # Meter IDs filter and message types (omitted in listen mode when meters is empty)
+    # Meter IDs filter and message types. In listen mode (no meters configured),
+    # skip -filterid and use -msgtype=all so rtlamr decodes every supported
+    # protocol — without this it defaults to scm-only and misses idm, r900, etc.
     if meters:
         args.append(f'-filterid={",".join(meters.keys())}')
         args.append(f'-msgtype={get_comma_separated_str("protocol", meters)}')
+    else:
+        args.append('-msgtype=all')
 
     return args
 

--- a/rtlamr2mqtt-addon/app/helpers/info.py
+++ b/rtlamr2mqtt-addon/app/helpers/info.py
@@ -6,7 +6,7 @@ def version():
     """
     Returns the version of the application.
     """
-    return '2026.5.3'
+    return '2026.5.9'
 
 def origin_url():
     """

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: rtlamr2mqtt
-version: 2026.5.3
+version: 2026.5.9
 slug: rtlamr2mqtt
 panel_icon: mdi:gauge
 description: RTLAMR to MQTT Bridge

--- a/rtlamr2mqtt-addon/tests/test_buildcmd.py
+++ b/rtlamr2mqtt-addon/tests/test_buildcmd.py
@@ -56,10 +56,13 @@ class TestBuildRtlamrArgsListenMode:
         args = build_rtlamr_args(sample_config)
         assert not any(a.startswith('-filterid=') for a in args)
 
-    def test_no_msgtype_when_no_meters(self, sample_config):
+    def test_msgtype_all_when_no_meters(self, sample_config):
+        """Listen mode must use -msgtype=all so rtlamr decodes every protocol,
+        not just the SCM default."""
         sample_config['meters'] = {}
         args = build_rtlamr_args(sample_config)
-        assert not any(a.startswith('-msgtype=') for a in args)
+        msgtype_args = [a for a in args if a.startswith('-msgtype=')]
+        assert msgtype_args == ['-msgtype=all']
 
     def test_format_and_server_still_present_in_listen_mode(self, sample_config):
         sample_config['meters'] = {}


### PR DESCRIPTION
## Summary

When `general.listen_mode: true` is set, rtlamr2mqtt was silently restricting listen mode to **SCM-only** because rtlamr defaults `-msgtype` to `scm` when the flag is omitted. Users with idm, netidm, r900, r900bcd, or scm+ meters would never see them in the logs.

**Fix:** explicitly pass `-msgtype=all` when no meters are configured, so rtlamr decodes every protocol it knows about.

## Changes

- [helpers/buildcmd.py](rtlamr2mqtt-addon/app/helpers/buildcmd.py) — append `-msgtype=all` when meters dict is empty
- [tests/test_buildcmd.py](rtlamr2mqtt-addon/tests/test_buildcmd.py) — replace `test_no_msgtype_when_no_meters` with `test_msgtype_all_when_no_meters` asserting the args contain exactly `-msgtype=all`
- Version bumped to **2026.5.9** with matching CHANGELOG entry

## Test plan

- [x] All 17 buildcmd tests pass
- [ ] In a real environment with non-SCM meters, enable listen_mode and confirm `New meter` lines appear with Type values other than `SCM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)