### PR TITLE
Recover local rtl_tcp stalls from rtlamr read timeouts

### DIFF
--- a/rtlamr2mqtt-addon/app/meter_reader.py
+++ b/rtlamr2mqtt-addon/app/meter_reader.py
@@ -39,6 +39,24 @@ class MeterReader:
         self.listen_mode = config['general']['listen_mode']
         self._seen_ids: set = set()
 
+    def _recent_output_contains(self, *needles: str) -> bool:
+        output = '\n'.join(self.rtlamr.recent_output).lower()
+        return all(needle.lower() in output for needle in needles)
+
+    async def _recover_rtltcp(self, reset_usb: bool) -> bool:
+        await self.rtltcp.stop()
+        if reset_usb:
+            device_index = self.config['general']['device_id']
+            logger.warning(
+                'Resetting USB device at index %d after rtlamr read timeout',
+                device_index,
+            )
+            usbutil.reset_usb_device(device_index)
+        if not await self.rtltcp.start_with_retry():
+            return False
+        await usbutil.tickle_rtl_tcp(self.rtltcp_host)
+        return True
+
     async def run(self):
         """
         Main reading loop. Reads from rtlamr, parses, enqueues.
@@ -65,11 +83,22 @@ class MeterReader:
                                 'rtlamr last output before exit:\n  %s',
                                 '\n  '.join(self.rtlamr.recent_output),
                             )
+                        if (
+                            not self.is_remote
+                            and self._recent_output_contains('rcvr.read', 'i/o timeout')
+                        ):
+                            logger.warning(
+                                'rtlamr exited after rtl_tcp read timeout, forcing rtl_tcp recovery'
+                            )
+                            if not await self._recover_rtltcp(reset_usb=True):
+                                logger.error('Failed to recover rtl_tcp, shutting down')
+                                self.shutdown_event.set()
+                                return
                         # If rtl_tcp also died (e.g. shared USB error), restart it first
                         # so rtlamr's reconnect attempts have something to talk to.
-                        if not self.is_remote and not self.rtltcp.is_alive:
+                        elif not self.is_remote and not self.rtltcp.is_alive:
                             logger.warning('rtl_tcp also died, restarting it first')
-                            if not await self.rtltcp.start_with_retry():
+                            if not await self._recover_rtltcp(reset_usb=False):
                                 logger.error('Failed to restart rtl_tcp, shutting down')
                                 self.shutdown_event.set()
                                 return

--- a/rtlamr2mqtt-addon/tests/test_meter_reader.py
+++ b/rtlamr2mqtt-addon/tests/test_meter_reader.py
@@ -205,7 +205,7 @@ class TestMeterReaderListenMode:
 
 class TestMeterReaderProcessRestart:
     async def test_restart_on_rtlamr_death(self, reader, mock_rtlamr):
-        """If rtlamr dies (read_line returns None), it should be restarted."""
+        """If rtlamr dies without the timeout signature, only rtlamr should restart."""
         call_count = 0
         async def fake_read_line():
             nonlocal call_count
@@ -216,11 +216,14 @@ class TestMeterReaderProcessRestart:
             return None
         mock_rtlamr.read_line = fake_read_line
         mock_rtlamr.is_alive = False
+        mock_rtlamr.recent_output = ['unexpected EOF']
 
-        await reader.run()
+        with patch('meter_reader.usbutil.reset_usb_device') as reset_usb:
+            await reader.run()
 
         # Should have attempted to restart rtlamr
         assert mock_rtlamr.start_with_retry.call_count >= 1
+        reset_usb.assert_not_called()
 
     async def test_shutdown_on_failed_restart(self, reader, mock_rtlamr):
         """If rtlamr can't restart, shutdown_event should be set."""
@@ -231,3 +234,73 @@ class TestMeterReaderProcessRestart:
         await reader.run()
 
         assert reader.shutdown_event.is_set()
+
+    async def test_timeout_signature_forces_rtltcp_recovery(
+        self, reader, mock_rtlamr, mock_rtltcp
+    ):
+        """The rcvr.Read i/o timeout path should reset USB and restart rtl_tcp first."""
+        call_count = 0
+
+        async def fake_read_line():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            reader.shutdown_event.set()
+            return None
+
+        mock_rtlamr.read_line = fake_read_line
+        mock_rtlamr.is_alive = False
+        mock_rtlamr.recent_output = [
+            'time=2026-05-13T22:20:05.055-04:00 level=ERROR msg=receiver '
+            'error="read tcp 127.0.0.1:58502->127.0.0.1:1234: i/o timeout',
+            'rcvr.Read',
+        ]
+
+        with (
+            patch('meter_reader.usbutil.reset_usb_device') as reset_usb,
+            patch('meter_reader.usbutil.tickle_rtl_tcp', new=AsyncMock()) as tickle_rtl_tcp,
+        ):
+            await reader.run()
+
+        mock_rtltcp.stop.assert_awaited()
+        mock_rtltcp.start_with_retry.assert_awaited()
+        reset_usb.assert_called_once_with(0)
+        tickle_rtl_tcp.assert_awaited_once_with('127.0.0.1:1234')
+        mock_rtlamr.start_with_retry.assert_awaited()
+
+    async def test_remote_timeout_signature_skips_local_usb_recovery(
+        self, sample_config, mock_rtlamr, mock_rtltcp
+    ):
+        """Remote rtl_tcp should not try to stop/reset local USB on timeout."""
+        queue = asyncio.Queue()
+        shutdown = asyncio.Event()
+        reader = MeterReader(
+            config=sample_config,
+            rtlamr=mock_rtlamr,
+            rtltcp=mock_rtltcp,
+            reading_queue=queue,
+            shutdown_event=shutdown,
+            is_remote=True,
+        )
+        call_count = 0
+
+        async def fake_read_line():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            reader.shutdown_event.set()
+            return None
+
+        mock_rtlamr.read_line = fake_read_line
+        mock_rtlamr.is_alive = False
+        mock_rtlamr.recent_output = ['i/o timeout', 'rcvr.Read']
+
+        with patch('meter_reader.usbutil.reset_usb_device') as reset_usb:
+            await reader.run()
+
+        mock_rtltcp.stop.assert_not_awaited()
+        mock_rtltcp.start_with_retry.assert_not_awaited()
+        reset_usb.assert_not_called()
+        mock_rtlamr.start_with_retry.assert_awaited()


### PR DESCRIPTION
## Summary

- treat the `rcvr.Read` + `i/o timeout` rtlamr exit signature as an `rtl_tcp` stall, even when `rtl_tcp` is still alive
- force the local recovery path for that case: stop `rtl_tcp`, reset the USB device, restart `rtl_tcp`, tickle it, then restart `rtlamr`
- add regression tests that keep the non-timeout restart path unchanged and leave remote `rtl_tcp` untouched

## Raw logs from the failure that motivated this

```text
[2026-05-13 22:20:05,056] WARNING: rtlamr process died (exit code: 1), attempting restart
[2026-05-13 22:20:05,056] WARNING: rtlamr last output before exit:
  /go/pkg/mod/github.com/bemasher/
  time=2026-05-13T22:20:00.052-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:45 msg="CenterFreq: 912380000"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:46 msg="SampleRate: 2359296"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:47 msg="DataRate: 32768"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:48 msg="ChipLength: 72"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:49 msg="PreambleSymbols: 32"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:50 msg="PreambleLength: 4608"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:51 msg="PacketSymbols: 116"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:52 msg="PacketLength: 16704"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:59 msg="Protocols: scm,r900"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/protocol/decode.go:60 msg="Preambles: 111110010101001100000,00000000000000001110010101100100"
  time=2026-05-13T22:20:00.054-04:00 level=INFO source=rtlamr@v0.9.5/main.go:129 msg=rtl_tcp GainCount=14
  time=2026-05-13T22:20:05.055-04:00 level=INFO source=rtlamr@v0.9.5/main.go:374 msg="receiver context cancelled"
  time=2026-05-13T22:20:05.055-04:00 level=ERROR source=rtlamr@v0.9.5/main.go:350 msg=receiver error="read tcp 127.0.0.1:58502->127.0.0.1:1234: i/o timeout\nrcvr.Read\nmain.(*Receiver).Run.func2\n\t/go/pkg/mod/github.com/bemasher/rtlamr@v0.9.5/main.go:183\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700"
```

## Manual recovery

In this instance, a manual `usbreset` on the RTL-SDR followed by an add-on restart fixed the problem immediately. That is a pretty strong signal that this path should be treated as a stalled local `rtl_tcp` / USB state, not just a generic `rtlamr` exit... so I'd like to autodetect it.

## Why this path

The simpler alternative would be to treat any `rtlamr` exit code `1` as a reason to reset USB and restart `rtl_tcp`. That seemed pretty broad, but would be a lot simpler if you're open to it!

Issue #384 deliberately stopped resetting USB on every normal restart because aggressive resets were destabilizing devices over time. Going back to "exit code 1 means reset USB" would partially undo that change, since `rtlamr` uses exit code `1` for multiple failure modes that are not all hardware stalls. But if the failures are rare enough... 

This patch keeps the #384 intent intact by only escalating when the captured recent output matches the specific `rtl_tcp` read-timeout signature:

- `rcvr.Read`
- `i/o timeout`

## Tradeoff / note

I think #384 may have exposed some transient USB / `rtl_tcp` stalls that used to get papered over by the old always-reset behavior. Those stalls were probably still happening before, but the aggressive reset path masked them by recovering every cycle.

## Testing

I have a forked version of this running on Home Assistant with logs going to `/config` - 
```bash
ha addons logs --follow bb6e25e0_rtlamr2mqtt \
   | tee -a /config/rtlamr2mqtt-2026-05-13-full.log \
   | awk "/rtlamr exited after rtl_tcp read timeout|Resetting USB device at index|Failed to recover rtl_tcp|i\\/o timeout|rcvr.Read/" \
   >> /config/rtlamr2mqtt-2026-05-13-matches.log
```

Hopefully after a couple days I'll check and see it did something! 
