### PR TITLE
Max Scan Time (with must-find option)

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: rtlamr2mqtt
-url: https://github.com/allangood/rtlamr2mqtt
+url: https://github.com/ChuckMash/rtlamr2mqtt
 maintainer: allangood

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: rtlamr2mqtt
-url: https://github.com/ChuckMash/rtlamr2mqtt
+url: https://github.com/allangood/rtlamr2mqtt
 maintainer: allangood

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -80,6 +80,8 @@ def load_config(config_path=None):
     # General section
     general['listen_mode'] = bool(general.get('listen_mode', False))
     general['sleep_for'] = int(general.get('sleep_for', 0))
+    general['max_scan_time'] = int(general.get('max_scan_time', 0))
+    general['expose_attributes'] = bool(general.get('expose_attributes', False))
     general['verbosity'] = str(general.get('verbosity', 'info'))
     general['device_id'] = int(general.get('device_id', 0))
     general['rtltcp_host'] = str(general.get('rtltcp_host', '127.0.0.1:1234'))
@@ -120,10 +122,11 @@ def load_config(config_path=None):
     meters_allowed_keys = [
         'id', 'protocol', 'name', 'format', 'unit_of_measurement',
         'icon', 'device_class', 'state_class', 'expire_after',
-        'force_update', 'manufacturer', 'model',
+        'force_update', 'manufacturer', 'model', 'must_find',
     ]
     for m in config.get('meters') or []:
         m['state_class'] = m.get('state_class', 'total_increasing')
+        m['must_find'] = bool(m.get('must_find', False))
         meters[str(m['id'])] = {key: value for key, value in m.items() if key in meters_allowed_keys}
 
     return ('success', 'Config loaded successfully', {

--- a/rtlamr2mqtt-addon/app/helpers/config.py
+++ b/rtlamr2mqtt-addon/app/helpers/config.py
@@ -81,7 +81,6 @@ def load_config(config_path=None):
     general['listen_mode'] = bool(general.get('listen_mode', False))
     general['sleep_for'] = int(general.get('sleep_for', 0))
     general['max_scan_time'] = int(general.get('max_scan_time', 0))
-    general['expose_attributes'] = bool(general.get('expose_attributes', False))
     general['verbosity'] = str(general.get('verbosity', 'info'))
     general['device_id'] = int(general.get('device_id', 0))
     general['rtltcp_host'] = str(general.get('rtltcp_host', '127.0.0.1:1234'))

--- a/rtlamr2mqtt-addon/app/meter_reader.py
+++ b/rtlamr2mqtt-addon/app/meter_reader.py
@@ -75,7 +75,7 @@ class MeterReader:
             meters_seen = set()
             scan_deadline = (
                 asyncio.get_event_loop().time() + self.max_scan_time
-                if self.max_scan_time > 0 else None
+                if self.max_scan_time > 0 and not self.listen_mode else None
             )
             if scan_deadline is not None:
                 logger.info('Starting scan with max scan time of %d seconds', self.max_scan_time)

--- a/rtlamr2mqtt-addon/app/meter_reader.py
+++ b/rtlamr2mqtt-addon/app/meter_reader.py
@@ -34,7 +34,11 @@ class MeterReader:
         self.shutdown_event = shutdown_event
         self.is_remote = is_remote
         self.meter_ids = list(config['meters'].keys())
+        self.must_find_ids = {
+            mid for mid, cfg in config['meters'].items() if cfg.get('must_find')
+        }
         self.sleep_for = config['general']['sleep_for']
+        self.max_scan_time = config['general']['max_scan_time']
         self.rtltcp_host = config['general']['rtltcp_host']
         self.listen_mode = config['general']['listen_mode']
         self._seen_ids: set = set()
@@ -69,10 +73,45 @@ class MeterReader:
         """
         while not self.shutdown_event.is_set():
             meters_seen = set()
+            scan_deadline = (
+                asyncio.get_event_loop().time() + self.max_scan_time
+                if self.max_scan_time > 0 else None
+            )
+            if scan_deadline is not None:
+                logger.info('Starting scan with max scan time of %d seconds', self.max_scan_time)
+            logged_must_find_wait = False
 
-            # Read until shutdown or all meters seen (when sleep_for > 0)
+            # Read until shutdown, all meters seen, or max_scan_time elapsed
             while not self.shutdown_event.is_set():
-                line = await self.rtlamr.read_line()
+                if scan_deadline is not None:
+                    remaining = scan_deadline - asyncio.get_event_loop().time()
+                    if remaining <= 0:
+                        if self.must_find_ids <= meters_seen:
+                            logger.info(
+                                '%d/%d meters seen',
+                                len(meters_seen), len(self.meter_ids),
+                            )
+                            break
+                        if not logged_must_find_wait:
+                            logger.info('Max scan time reached, but must_find meters missing, continue scanning')
+                            logged_must_find_wait = True
+                        line = await self.rtlamr.read_line()
+                    else:
+                        try:
+                            line = await asyncio.wait_for(self.rtlamr.read_line(), timeout=remaining)
+                        except asyncio.TimeoutError:
+                            if self.must_find_ids <= meters_seen:
+                                logger.info(
+                                    '%d/%d meters seen',
+                                    len(meters_seen), len(self.meter_ids),
+                                )
+                                break
+                            if not logged_must_find_wait:
+                                logger.info('Max scan time reached, but must_find meters missing, continue scanning')
+                                logged_must_find_wait = True
+                            line = await self.rtlamr.read_line()
+                else:
+                    line = await self.rtlamr.read_line()
 
                 if line is None:
                     # Process died or stdout closed

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -17,14 +17,15 @@ hassio_api: true
 arch:
   - amd64
   - aarch64
-image: "allangood/rtlamr2mqtt"
 services:
   - mqtt:need
 options:
   general:
     sleep_for: 60
+    max_scan_time: 0
     verbosity: info
     listen_mode: false
+    expose_attributes: false
   custom_parameters: {}
   mqtt:
     ha_autodiscovery_topic: homeassistant
@@ -36,10 +37,12 @@ options:
 schema:
   general:
     sleep_for: "int?"
+    max_scan_time: "int?"
     verbosity: "list(debug|info|warning|critical|none)?"
     device_id: "int?"
     rtltcp_host: "str?"
     listen_mode: "bool?"
+    expose_attributes: "bool?"
   mqtt:
     host: "str?"
     port: "int?"
@@ -70,3 +73,4 @@ schema:
       force_update: bool?
       manufacturer: "str?"
       model: "str?"
+      must_find: "bool?"

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -17,6 +17,7 @@ hassio_api: true
 arch:
   - amd64
   - aarch64
+image: "allangood/rtlamr2mqtt"
 services:
   - mqtt:need
 options:

--- a/rtlamr2mqtt-addon/config.yaml
+++ b/rtlamr2mqtt-addon/config.yaml
@@ -26,7 +26,6 @@ options:
     max_scan_time: 0
     verbosity: info
     listen_mode: false
-    expose_attributes: false
   custom_parameters: {}
   mqtt:
     ha_autodiscovery_topic: homeassistant
@@ -43,7 +42,6 @@ schema:
     device_id: "int?"
     rtltcp_host: "str?"
     listen_mode: "bool?"
-    expose_attributes: "bool?"
   mqtt:
     host: "str?"
     port: "int?"

--- a/rtlamr2mqtt-addon/tests/conftest.py
+++ b/rtlamr2mqtt-addon/tests/conftest.py
@@ -12,6 +12,7 @@ def sample_config():
     return {
         'general': {
             'sleep_for': 0,
+            'max_scan_time': 0,
             'verbosity': 'info',
             'device_id': 0,
             'rtltcp_host': '127.0.0.1:1234',


### PR DESCRIPTION
This PR introduces  `max_scan_time` to general settings and a `must_find` setting to each meter.

* `max_scan_time` (general): How long a scanning window, in seconds, can run before moving into sleep, instead of waiting indefinitely for every meter to be heard (with exception of `must_find` enabled meters). 0 (default) retains current indefinite scanning window until all meters found.

* `must_find` (per-meter): flags specific meters as mission-critical. Meters with this flag will force the scanning window to continue beyond `max_scan_time` until found. This setting is only relevant when `max_scan_time` is set.



